### PR TITLE
Make Plugin_Dependencies::deactivate_conflicting() public

### DIFF
--- a/lib/wp-plugin-dependencies/plugin-dependencies.php
+++ b/lib/wp-plugin-dependencies/plugin-dependencies.php
@@ -306,7 +306,7 @@ class Plugin_Dependencies {
 	 * @param array $plugin_ids A list of plugin basenames
 	 * @return array List of deactivated plugins
 	 */
-	protected static function deactivate_conflicting( $to_activate ) {
+	public static function deactivate_conflicting( $to_activate ) {
 		$deps = array();
 		foreach ( $to_activate as $plugin_id ) {
 			$deps = array_merge( $deps, self::get_provided( $plugin_id ) );


### PR DESCRIPTION
Declare `Plugin_Dependencies::deactivate_conflicting()` to be a `public` method because it is called externally from `Plugin_Dependencies_UI::init()` every time a plugin is activated.

Fixes code changed [here](https://github.com/cuny-academic-commons/commons-in-a-box/commit/fcd2aa9f98b9827863e258942105e2e51075bf2e#diff-8fbb20b6f6f2d4fddeeb6aa7cb4fb2daR309) and resolves non-critical issues such as [this](http://commonsinabox.org/groups/help-support/forum/topic/voting-on-blog-posts/) and [this](http://commonsinabox.org/groups/help-support/forum/topic/cbox-wont-let-me-activate-other-plugins/).
