### PR TITLE
Update the logo for Retina devices

### DIFF
--- a/admin/admin-loader.php
+++ b/admin/admin-loader.php
@@ -1374,7 +1374,12 @@ class CBox_Admin {
 			only screen and (min-device-pixel-ratio: 1.5) {
 				.wp-badge {
 					background-image: url( <?php echo $badge_url_2x; ?> );
-					background-size:  300px 364px;
+					background-size: 77%;
+					background-repeat: no-repeat;
+					width: 152px;
+					padding-top: 157px;
+					height: 34px;
+					top: 50px;
 				}
 		}
 


### PR DESCRIPTION
The logo was all messed up on retina devices. This commit fixes that! (see attached screenshots)

![screenshot 2014-02-19 17 46 32](https://f.cloud.github.com/assets/855037/2208967/b2593eb6-9985-11e3-9312-054bea6426c5.png)
![screenshot 2014-02-19 17 46 09](https://f.cloud.github.com/assets/855037/2208968/b25aa35a-9985-11e3-8379-d603ab75ed3d.png)
