### PR TITLE
Fix fatal error on front end when bbPress disabled on subsites

### DIFF
--- a/includes/frontend-bbpress.php
+++ b/includes/frontend-bbpress.php
@@ -167,7 +167,7 @@ class CBox_BBP_Autoload {
 		}
 
 		// we're hoping a fix is going to be ready by bbP 2.6
-		if ( version_compare( bbp_get_version(), '2.6' ) >= 0 ) {
+		if ( function_exists( 'bbp_get_version' ) AND version_compare( bbp_get_version(), '2.6' ) >= 0 ) {
 		        return;
 		}
 


### PR DESCRIPTION
When bbPress is force-disabled on sub-sites, commons-in-a-box throws a fatal error. Same issue as #100 essentially, because in some cases people do not want bbPress active on sites other than the main site. See, for example [this discussion](http://commonsinabox.org/groups/help-support/forum/topic/scope-of-bbpress-plugin-and-associated-issues/).
