### PR TITLE
Bail if BuddyPress is not yet present

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -58,6 +58,9 @@ class CBox_Frontend {
 	 * @since 1.0.1
 	 */
 	private function setup_globals() {
+		// bail if BuddyPress not yet present
+		if ( ! function_exists( 'bp_get_option' ) ) return;
+
 		// get our CBOX admin settings
 		$this->settings = (array) bp_get_option( cbox()->settings_key );
 


### PR DESCRIPTION
Fixes fatal error on the front end when CBOX has been activated but not yet configured. Steps to reproduce on clean install of WordPress multisite or standalone:

1. Install Commons in a Box plugin
2. Activate it
3. Visit front end of website
4. Boom!