### PR TITLE
Don't filter `all_plugins` when running WP-CLI.

### DIFF
--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -86,6 +86,10 @@ class CBox_Admin_Plugins {
 	 * @return array
 	 */
 	public function exclude_cbox_plugins( $plugins ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return $plugins;
+		}
+
 		$plugins_by_name = Plugin_Dependencies::$plugins_by_name;
 
 		if ( is_multisite() ) {


### PR DESCRIPTION
It's not currently possible to manage CBOX plugins via CLI, unless `CBOX_OVERRIDE_PLUGINS` is set. It seems to me that anyone using wp-cli is the kind of person who would want the ability to override, even if that person doesn't want plugins to be managed via the Dashboard. So, two questions:

1. Does that seem right to you?

2. Does suppressing `all_plugins` filter - but allowing the other `! is_override()` stuff to apply, preventing update checks, etc - seem like the right place for this mod?

Feel free to say I'm crazy - this is a minor annoyance.