### PR TITLE
Fix PHP 5.3 compatibility issues.

### DIFF
--- a/includes/classic/plugins.php
+++ b/includes/classic/plugins.php
@@ -37,7 +37,7 @@ class CBox_Plugins_Classic {
 	 */
 	protected static function register_required_plugins( $instance ) {
 		// BuddyPress
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress',
 			'cbox_name'         => __( 'BuddyPress', 'cbox' ),
 			'cbox_description'  => __( 'BuddyPress provides the core functionality of Commons In A Box, including groups and user profiles.', 'cbox' ),
@@ -59,7 +59,7 @@ class CBox_Plugins_Classic {
 		 *
 		 * @see CBox_Plugins::register_plugin()
 		 */
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'  => 'BuddyPress',
 			'type'         => 'dependency',
 			'download_url' => 'http://downloads.wordpress.org/plugin/buddypress.3.2.0.zip'
@@ -75,7 +75,7 @@ class CBox_Plugins_Classic {
 	 */
 	protected static function register_recommended_plugins( $instance ) {
 		// BuddyPress Docs
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Docs',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'Docs', 'cbox' ),
@@ -90,21 +90,21 @@ class CBox_Plugins_Classic {
 		) );
 
 		// BuddyPress Docs Wiki
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Docs Wiki add-on',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'Wiki', 'cbox' ),
 			'cbox_description'  => __( 'A sitewide wiki, powered by BuddyPress Docs', 'cbox' ),
 			'version'           => '1.0.10',
 			'depends'           => 'BuddyPress (>=1.5), BuddyPress Docs (>=1.2)',
-			'download_url'      => 'http://github.com/boonebgorges/buddypress-docs-wiki/archive/1.0.10.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/buddypress-docs-wiki-1.0.10.zip',
 			'documentation_url' => 'http://commonsinabox.org/documentation/plugins/buddypress-docs-wiki',
 			'network_settings'  => 'root-blog-only',
 			'network'           => false
 		) );
 
 		// BuddyPress Group Email Subscription
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Group Email Subscription',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'Group Email Subscription', 'cbox' ),
@@ -118,7 +118,7 @@ class CBox_Plugins_Classic {
 		) );
 
 		// Invite Anyone
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'Invite Anyone',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'Invite Anyone', 'cbox' ),
@@ -133,7 +133,7 @@ class CBox_Plugins_Classic {
 		) );
 
 		// Custom Profile Filters for BuddyPress
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'Custom Profile Filters for BuddyPress',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'Custom Profile Filters', 'cbox' ),
@@ -146,7 +146,7 @@ class CBox_Plugins_Classic {
 		) );
 
 		// bbPress
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'bbPress',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'bbPress Forums', 'cbox' ),
@@ -161,7 +161,7 @@ class CBox_Plugins_Classic {
 		) );
 
 		// CAC Featured Content
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'CAC Featured Content',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'Featured Content Widget', 'cbox' ),
@@ -172,14 +172,14 @@ class CBox_Plugins_Classic {
 		) );
 
 		// BuddyPress Group Email Subscription
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BP Group Announcements',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'Group Announcements', 'cbox' ),
 			'cbox_description'  => __( 'Repurposes group activity updates, using an Announcements tab to groups.', 'cbox' ),
 			'depends'           => 'BuddyPress (>=1.5)',
 			'version'           => '1.0.5',
-			'download_url'      => 'http://github.com/cuny-academic-commons/bp-group-announcements/archive/1.0.5.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/bp-group-announcements-1.0.5.zip',
 			'documentation_url' => 'http://commonsinabox.org/documentation/plugins/bp-group-announcements',
 			'network'           => false
 		) );
@@ -187,7 +187,7 @@ class CBox_Plugins_Classic {
 		// Only show the following plugins if multisite is enabled.
 		if ( is_multisite() ) :
 			// More Privacy Options
-			$instance( array(
+			call_user_func($instance, array(
 				'plugin_name'       => 'More Privacy Options',
 				'type'              => 'recommended',
 				'cbox_name'         => __( 'More Privacy Options', 'cbox' ),
@@ -199,7 +199,7 @@ class CBox_Plugins_Classic {
 			) );
 
 			// BP MPO Activity Filter
-			$instance( array(
+			call_user_func($instance, array(
 				'plugin_name'       => 'BP MPO Activity Filter',
 				'type'              => 'recommended',
 				'cbox_name'         => __( 'Activity Privacy', 'cbox' ),
@@ -210,7 +210,7 @@ class CBox_Plugins_Classic {
 			) );
 
 			// BuddyPress GroupBlog
-			$instance( array(
+			call_user_func($instance, array(
 				'plugin_name'       => 'BP Groupblog',
 				'type'              => 'recommended',
 				'cbox_name'         => __( 'Group Blogs', 'cbox' ),
@@ -234,28 +234,28 @@ class CBox_Plugins_Classic {
 	 */
 	protected static function register_optional_plugins( $instance ) {
 		// BuddyPress External Group Blogs
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'External Group Blogs',
 			'type'              => 'optional',
 			'cbox_name'         => __( 'External RSS Feeds for Groups', 'cbox' ),
 			'cbox_description'  => __( 'Gives group creators and administrators the ability to attach external RSS feeds to groups.', 'cbox' ),
 			'depends'           => 'BuddyPress (>=1.5)',
 			'version'           => '1.6.1',
-			'download_url'      => 'http://github.com/cuny-academic-commons/external-group-blogs/archive/1.6.1.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/external-group-blogs-1.6.1.zip',
 			'documentation_url' => 'http://commonsinabox.org/documentation/plugins/buddypress-external-group-rss',
 			'network'           => false
 		) );
 
 		// BuddyPress Reply By Email
 		// @todo Still need to add it in the wp.org plugin repo! Using Github for now.
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Reply By Email',
 			'type'              => 'optional',
 			'cbox_name'         => __( 'Reply By Email', 'cbox' ),
 			'cbox_description'  => __( "Reply to content from all over the community from the comfort of your email inbox", 'cbox' ),
 			'version'           => '1.0-RC7',
 			'depends'           => 'BuddyPress (>=1.5)',
-			'download_url'      => 'https://github.com/r-a-y/bp-reply-by-email/archive/1.0-RC7.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/bp-reply-by-email-1.0-RC7.zip',
 			'documentation_url' => 'http://commonsinabox.org/documentation/plugins/buddypress-reply-by-email',
 			'admin_settings'    => is_multisite() ? 'options-general.php?page=bp-rbe' : 'admin.php?page=bp-rbe',
 			'network_settings'  => 'root-blog-only'

--- a/includes/openlab/plugins.php
+++ b/includes/openlab/plugins.php
@@ -39,7 +39,7 @@ class CBox_Plugins_OpenLab {
 	 */
 	protected static function register_required_plugins( $instance ) {
 		// BuddyPress
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress',
 			'cbox_name'         => __( 'BuddyPress', 'cbox' ),
 			'cbox_description'  => __( 'BuddyPress provides the core functionality of Commons In A Box, including groups and user profiles.', 'cbox' ),
@@ -50,17 +50,17 @@ class CBox_Plugins_OpenLab {
 		) );
 
 		// CBOX-OpenLab Core
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'CBOX-OpenLab Core',
 			'cbox_name'         => __( 'OpenLab Core', 'cbox' ),
 			'cbox_description'  => __( 'Core functionality for CBOX-OpenLab.', 'cbox' ),
 			'version'           => '1.1.0',
-			'download_url'      => 'https://github.com/cuny-academic-commons/cbox-openlab-core/archive/1.1.0.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/cbox-openlab-core-1.1.0.zip',
 			//'documentation_url' => 'http://commonsinabox.org/documentation/plugins/buddypress-plugin',
 		) );
 
 		// bbPress
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'bbPress',
 			'cbox_name'         => __( 'bbPress Forums', 'cbox' ),
 			'cbox_description'  => __( 'Sitewide and group-specific discussion forums.', 'cbox' ),
@@ -74,7 +74,7 @@ class CBox_Plugins_OpenLab {
 		) );
 
 		// BuddyPress Docs
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Docs',
 			'cbox_name'         => __( 'Docs', 'cbox' ),
 			'cbox_description'  => __( 'Allows your members to collaborate on wiki-style Docs.', 'cbox' ),
@@ -88,20 +88,20 @@ class CBox_Plugins_OpenLab {
 		) );
 
 		// BuddyPress Docs In Group
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Docs In Group',
 			'cbox_name'         => __( 'Docs in Group', 'cbox' ),
 			'cbox_description'  => __( 'Put BuddyPress Docs into the Group context.', 'cbox' ),
 			'version'           => '1.0.1',
 			'depends'           => 'BuddyPress (>=1.5)',
-			'download_url'      => 'https://github.com/boonebgorges/buddypress-docs-in-group/archive/1.0.1.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/buddypress-docs-in-group-1.0.1.zip',
 			'documentation_url' => 'http://commonsinabox.org/documentation/plugins/buddypress-docs',
 			'network_settings'  => 'root-blog-only',
 			'network'           => false,
 		) );
 
 		// BP Group Documents
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BP Group Documents',
 			'cbox_name'         => __( 'Group Documents', 'cbox' ),
 			'cbox_description'  => __( 'Allow your members to attach documents to groups.', 'cbox' ),
@@ -114,7 +114,7 @@ class CBox_Plugins_OpenLab {
 		) );
 
 		// BuddyPress Group Email Subscription
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Group Email Subscription',
 			'cbox_name'         => __( 'Group Email Subscription', 'cbox' ),
 			'cbox_description'  => __( 'Allows your community members to receive email notifications of activity within their groups.', 'cbox' ),
@@ -130,7 +130,7 @@ class CBox_Plugins_OpenLab {
 		// This is custom-developed and is only included in the main openlab repo
 		// We'll break it out into its own.
 		// BP Customizable Group Categories
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BP Customizable Group Categories',
 			'cbox_name'         => __( 'BP Customizable Group Categories', 'cbox' ),
 			'cbox_description'  => __( 'Categories for BuddyPress Groups', 'cbox' ),
@@ -142,7 +142,7 @@ class CBox_Plugins_OpenLab {
 		*/
 
 		// Invite Anyone
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'Invite Anyone',
 			'cbox_name'         => __( 'Invite Anyone', 'cbox' ),
 			'cbox_description'  => __( 'An enhanced interface for inviting existing community members to groups, as well as a powerful tool for sending invitations, via email, to potential members.', 'cbox' ),
@@ -156,7 +156,7 @@ class CBox_Plugins_OpenLab {
 		) );
 
 		// CAC Featured Content
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'CAC Featured Content',
 			'cbox_name'         => __( 'Featured Content Widget', 'cbox' ),
 			'cbox_description'  => __( 'Provides a widget that allows you to select among five different content types to feature in a widget area.', 'cbox' ),
@@ -166,7 +166,7 @@ class CBox_Plugins_OpenLab {
 		) );
 
 		// More Privacy Options
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'More Privacy Options',
 			'cbox_name'         => __( 'More Privacy Options', 'cbox' ),
 			'cbox_description'  => __( 'Adds more blog privacy options for your users.', 'cbox' ),
@@ -194,14 +194,14 @@ class CBox_Plugins_OpenLab {
 	 */
 	protected static function register_dependency_plugins( $instance ) {
 		// BuddyPress
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'  => 'BuddyPress',
 			'type'         => 'dependency',
 			'download_url' => 'http://downloads.wordpress.org/plugin/buddypress.3.2.0.zip'
 		) );
 
 		// Event Organiser
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'  => 'Event Organiser',
 			'type'         => 'dependency',
 			'version'      => '3.6.5',
@@ -211,7 +211,7 @@ class CBox_Plugins_OpenLab {
 		) );
 
 		// Braille
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'  => 'Braille',
 			'type'         => 'dependency',
 			'version'      => '0.0.6',
@@ -230,14 +230,14 @@ class CBox_Plugins_OpenLab {
 	 */
 	protected static function register_recommended_plugins( $instance ) {
 		// BP Event Organiser
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Event Organiser',
 			'type'              => 'recommended',
 			'cbox_name'         => __( 'Events', 'cbox' ),
 			'cbox_description'  => __( 'Allows your members to create a calendar for themselves and to attach specific events to groups.', 'cbox' ),
 			'version'           => '0.2',
 			'depends'           => 'BuddyPress (>=1.5), Event Organiser (>=3.1)',
-			'download_url'      => 'https://github.com/cuny-academic-commons/bp-event-organiser/archive/1.1.x.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/bp-event-organiser-1.1.x.zip',
 			'network'           => false
 		) );
 	}
@@ -252,28 +252,28 @@ class CBox_Plugins_OpenLab {
 	protected static function register_optional_plugins( $instance ) {
 		// BuddyPress Reply By Email
 		// @todo Still need to add it in the wp.org plugin repo! Using Github for now.
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BuddyPress Reply By Email',
 			'type'              => 'optional',
 			'cbox_name'         => __( 'Reply By Email', 'cbox' ),
 			'cbox_description'  => __( "Reply to content from all over the community from the comfort of your email inbox", 'cbox' ),
 			'version'           => '1.0-RC7',
 			'depends'           => 'BuddyPress (>=1.5)',
-			'download_url'      => 'https://github.com/r-a-y/bp-reply-by-email/archive/1.0-RC7.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/bp-reply-by-email-1.0-RC7.zip',
 			'documentation_url' => 'http://commonsinabox.org/documentation/plugins/buddypress-reply-by-email',
 			'admin_settings'    => is_multisite() ? 'options-general.php?page=bp-rbe' : 'admin.php?page=bp-rbe',
 			'network_settings'  => 'root-blog-only'
 		) );
 
 		// BP Braille
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'BP Braille',
 			'type'              => 'optional',
 			'cbox_name'         => __( 'Braille Support', 'cbox' ),
 			'cbox_description'  => __( 'An addon for the Braille plugin providing support for BuddyPress Group Forums and Private Messaging', 'cbox' ),
 			'version'           => '0.2.0',
 			'depends'           => 'Braille (>=0.0.3)',
-			'download_url'      => 'http://github.com/hard-g/bp-braille/archive/master.zip',
+			'download_url'      => CBOX_PLUGIN_DIR . 'includes/zip/bp-braille-master.zip',
 			'documentation_url' => 'https://wordpress.org/plugins/braille',
 			'network'           => false
 		) );
@@ -287,7 +287,7 @@ class CBox_Plugins_OpenLab {
 	 * @param callable $instance {@see CBox_Plugins::register_plugin()}.
 	 */
 	protected static function register_installonly_plugins( $instance ) {
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'Anthologize',
 			'type'              => 'install-only',
 			'cbox_name'         => __( 'Anthologize', 'cbox' ),
@@ -297,7 +297,7 @@ class CBox_Plugins_OpenLab {
 			'documentation_url' => 'https://wordpress.org/plugins/anthologize',
 		) );
 
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'Braille',
 			'type'              => 'install-only',
 			'cbox_name'         => __( 'Braille', 'cbox' ),
@@ -305,7 +305,7 @@ class CBox_Plugins_OpenLab {
 			'documentation_url' => 'https://wordpress.org/plugins/braille',
 		) );
 
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'PressForward',
 			'type'              => 'install-only',
 			'cbox_name'         => __( 'PressForward', 'cbox' ),
@@ -315,7 +315,7 @@ class CBox_Plugins_OpenLab {
 			'documentation_url' => 'https://wordpress.org/plugins/pressforward',
 		) );
 
-		$instance( array(
+		call_user_func($instance, array(
 			'plugin_name'       => 'WP Grade Comments',
 			'type'              => 'install-only',
 			'cbox_name'         => __( 'WP Grade Comments', 'cbox' ),


### PR DESCRIPTION
Resolves some issues that cause side-wide fatal errors when running the 1.1x plugin under PHP 5.3.

* Accommodates 5.3's lack of support for $this/self:: in closures by promoting to class functions
* Accomodates 5.3's less-extensive support for variable functions by replacing with calls to call_user_func() 