### PR TITLE
Fix fatal error on CBOX network admin dashboard

### DIFF
--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -183,7 +183,7 @@ class CBox_Admin_Plugins {
 
 		// BuddyPress complicates things due to a different root blog ID.
 		if ( 1 !== cbox_get_main_site_id() ) {
-			$cbox_plugins = self::get_plugins();
+			$cbox_plugins = CBox_Plugins::get_plugins();
 			$plugin_data  = get_plugin_data( WP_PLUGIN_DIR . '/' . $loader );
 
 			// 'network' flag is false, so switch to root blog.


### PR DESCRIPTION
On the CBOX Network admin screen (directly after a 1.1.0 upgrade) I get a fatal error:

```
PHP Fatal error: Uncaught Error: Call to undefined method CBox_Admin_Plugins::get_plugins() in /path-to/commons-in-a-box/admin/plugins.php:186
```

This PR fixes the problem by referencing the relevant class.