### PR TITLE
Make switch-to-blog-and-back logic compatible with multi-network

### DIFF
--- a/admin/admin-loader.php
+++ b/admin/admin-loader.php
@@ -214,16 +214,18 @@ class CBox_Admin {
 			// CBOX Theme options page!
 			if ( $theme->exists() ) {
 				// if BP_ROOT_BLOG is defined and we're not on the root blog, switch to it
-				if ( 1 !== cbox_get_main_site_id() ) {
+				if ( ! cbox_is_main_site() ) {
 					switch_to_blog( cbox_get_main_site_id() );
+					$switched = true;
 				}
 
 				// switch the theme
 				switch_theme( cbox_get_theme_prop( 'directory_name' ), cbox_get_theme_prop( 'directory_name' ) );
 
 				// restore blog after switching
-				if ( 1 !== cbox_get_main_site_id() ) {
+				if ( ! empty( $switched ) ) {
 					restore_current_blog();
+					unset( $switched );
 				}
 
 				// Mark the theme as having just been activated

--- a/admin/plugin-install.php
+++ b/admin/plugin-install.php
@@ -74,14 +74,16 @@ class CBox_Plugin_Upgrader extends Plugin_Upgrader {
 			 * BuddyPress supports a different root blog ID, so if BuddyPress is activated
 			 * we need to switch to that blog to get the correct active plugins list.
 			 */
-			if ( false === $current[ $plugin ]['network'] && 1 !== cbox_get_main_site_id() ) {
+			if ( false === $current[ $plugin ]['network'] && ! cbox_is_main_site() ) {
 				switch_to_blog( cbox_get_main_site_id() );
+				$switched = true;
 			}
 
 			$is_active = is_plugin_active( $plugin_loader );
 
-			if ( false === $current[ $plugin ]['network'] && 1 !== cbox_get_main_site_id() ) {
+			if ( false === $current[ $plugin ]['network'] && ! empty( $switched ) ) {
 				restore_current_blog();
+				unset( $switched );
 			}
 
 			// Only activate Maintenance mode if a plugin is active.
@@ -118,14 +120,16 @@ class CBox_Plugin_Upgrader extends Plugin_Upgrader {
 			 * BuddyPress supports a different root blog ID, so if BuddyPress is activated
 			 * we need to switch to that blog to get the correct active plugins list.
 			 */
-			if ( false === $current[ $plugin ]['network'] && 1 !== cbox_get_main_site_id() ) {
+			if ( false === $current[ $plugin ]['network'] && ! cbox_is_main_site() ) {
 				switch_to_blog( cbox_get_main_site_id() );
+				$switched = true;
 			}
 
 			$this->skin->plugin_active = is_plugin_active( $plugin_loader );
 
-			if ( false === $current[ $plugin ]['network'] && 1 !== cbox_get_main_site_id() ) {
+			if ( false === $current[ $plugin ]['network'] && ! empty( $switched ) ) {
 				restore_current_blog();
+				unset( $switched );
 			}
 
 			$result = $this->run( array(
@@ -277,8 +281,9 @@ class CBox_Plugin_Upgrader extends Plugin_Upgrader {
 			 * BuddyPress supports a different root blog ID, so if BuddyPress is activated
 			 * we need to switch to that blog to get the correct active plugins list.
 			 */
-			if ( false === $network_activate && 1 !== cbox_get_main_site_id() ) {
+			if ( false === $network_activate && ! cbox_is_main_site() ) {
 				switch_to_blog( cbox_get_main_site_id() );
+				$switched = true;
 			}
 
 			$is_active = is_plugin_active( $plugin_loader );
@@ -288,8 +293,9 @@ class CBox_Plugin_Upgrader extends Plugin_Upgrader {
 				unset( $plugins[ $i ] );
 
 				// Remember to restore blog, if we're skipping!
-				if ( false === $network_activate && 1 !== cbox_get_main_site_id() ) {
+				if ( false === $network_activate && ! empty( $switched ) ) {
 					restore_current_blog();
+					unset( $switched );
 				}
 
 				continue;
@@ -298,8 +304,9 @@ class CBox_Plugin_Upgrader extends Plugin_Upgrader {
 			// activate the plugin
 			activate_plugin( $plugin_loader, '', $network_activate );
 
-			if ( false === $network_activate && 1 !== cbox_get_main_site_id() ) {
+			if ( false === $network_activate && ! empty( $switched ) ) {
 				restore_current_blog();
+				unset( $switched );
 			}
 		}
 
@@ -831,15 +838,17 @@ class CBox_Updater {
 			 * BuddyPress supports a different root blog ID, so if BuddyPress is activated
 			 * we need to switch to that blog to get the correct active plugins list.
 			 */
-			if ( false === $network_activate && 1 !== cbox_get_main_site_id() ) {
+			if ( false === $network_activate && ! cbox_is_main_site() ) {
 				switch_to_blog( cbox_get_main_site_id() );
+				$switched = true;
 			}
 
 			// activate the plugin
 			activate_plugin( $plugin, '', $network_activate );
 
-			if ( false === $network_activate && 1 !== cbox_get_main_site_id() ) {
+			if ( false === $network_activate && ! empty( $switched ) ) {
 				restore_current_blog();
+				unset( $switched );
 			}
 		}
 

--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -182,7 +182,7 @@ class CBox_Admin_Plugins {
 		$is_active = null;
 
 		// BuddyPress complicates things due to a different root blog ID.
-		if ( 1 !== cbox_get_main_site_id() ) {
+		if ( ! cbox_is_main_site() ) {
 			$cbox_plugins = CBox_Plugins::get_plugins();
 			$plugin_data  = get_plugin_data( WP_PLUGIN_DIR . '/' . $loader );
 
@@ -457,8 +457,9 @@ class CBox_Admin_Plugins {
 						// Multisite
 						if ( is_multisite() ) {
 							// Darn BuddyPress...
-							if ( 1 !== cbox_get_main_site_id() ) {
+							if ( ! cbox_is_main_site() ) {
 								switch_to_blog( cbox_get_main_site_id() );
+								$switched = true;
 							}
 
 							// Deactivate dependent plugins on main site as well.
@@ -472,8 +473,9 @@ class CBox_Admin_Plugins {
 							deactivate_plugins( $plugin, false, is_plugin_active_for_network( $plugin ) );
 
 							// Switch back.
-							if ( 1 !== cbox_get_main_site_id() ) {
+							if ( ! empty( $switched ) ) {
 								restore_current_blog();
+								unset( $switched );
 							}
 
 						// Single site.
@@ -507,16 +509,18 @@ class CBox_Admin_Plugins {
 						// If plugin was activated on the CBOX site, refresh active plugins list.
 						} elseif ( ! is_wp_error( $result ) && self::is_plugin_active( $loader ) ) {
 							// Switch to CBOX main site ID, if necessary.
-							if ( 1 !== cbox_get_main_site_id() ) {
+							if ( ! cbox_is_main_site() ) {
 								switch_to_blog( cbox_get_main_site_id() );
+								$switched = true;
 							}
 
 							// Validate existing plugins.
 							validate_active_plugins();
 
 							// Switch back.
-							if ( 1 !== cbox_get_main_site_id() ) {
+							if ( ! empty( $switched ) ) {
 								restore_current_blog();
+								unset( $switched );
 							}
 						}
 					}

--- a/admin/theme-install.php
+++ b/admin/theme-install.php
@@ -173,16 +173,18 @@ class CBox_Theme_Installer extends Theme_Upgrader {
 
 		if ( ! empty( $result['destination_name'] ) && $result['destination_name'] == $directory_name ) {
 			// if BP_ROOT_BLOG is defined and we're not on the root blog, switch to it
-			if ( 1 !== cbox_get_main_site_id() ) {
+			if ( ! cbox_is_main_site() ) {
 				switch_to_blog( cbox_get_main_site_id() );
+				$switched = true;
 			}
 
 			// switch the theme
 			switch_theme( $directory_name, $directory_name );
 
 			// restore blog after switching
-			if ( 1 !== cbox_get_main_site_id() ) {
+			if ( ! empty( $switched ) ) {
 				restore_current_blog();
+				unset( $switched );
 			}
 
 			// Mark the theme as having just been activated

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -59,17 +59,43 @@ function cbox_get_main_site_id() {
 	}
 
 	/*
-	 * Multisite; see ms_load_current_site_and_network().
+	 * Multisite & Multi-network; see ms_load_current_site_and_network().
 	 *
 	 * This might not be necessary for 99% of installs out there, but better safe
 	 * than sorry!
+	 *
+	 * WP 4.9.8 introduced get_main_site_id() which is network-aware and returns
+	 * the correct ID for the main site of the current network.
 	 */
 	if ( is_multisite() ) {
-		return (int) get_current_site()->blog_id;
+		return (int) get_main_site_id();
 	}
 
 	// Fallback to 1 if we've reached this part.
 	return 1;
+}
+
+/**
+ * Convenience function to test if we are on the main site of a network.
+ *
+ * @since 1.1.1
+ *
+ * @return bool True if main site, false otherwise.
+ */
+function cbox_is_main_site() {
+	// Always true on single site instances.
+	if ( ! is_multisite() ) {
+		return true;
+	}
+
+	// Check against current site.
+	$site_id = (int) get_current_blog_id();
+	if ( $site_id === cbox_get_main_site_id() ) {
+		return true;
+	}
+
+	// Can't be the main site.
+	return false;
 }
 
 /**


### PR DESCRIPTION
Following on from discussion on #169 this PR makes calls to `switch_to_blog()` and `restore_current_blog()` compatible with WordPress multi-network installs and improves compatibility with multisite installs where the "main site" does not have `ID = 1`.

The code in this PR is slightly convoluted in that it introduces a local variable `$switched` which is set when we switch to the main site and is checked prior to calling `restore_current_blog()`. This is because "blog switching" maintains a stack of blogs which have been switched to and not checking prior to restoring may cause switches to unexpected blogs in the stack.

There are so many instances of `if ( 1 !== cbox_get_main_site_id() ) { .... }` in the existing code that I have introduced calls to a new function `cbox_is_main_site()` wherever this test takes place. My assumption is that on these occasions we need to be on the "main site" to perform the relevant tasks regardless of whether it's a standard or custom setup. @r-a-y I hope I've understood the intent of your code!

FWIW, I've tested this on a live multi-network install where CBOX is active on a "sub-network" whose "main site ID is not `1` and the upgrade went without a hitch.