### PR TITLE
Proof-of-concept for .pot combiner.

### DIFF
--- a/languages/cbox.pot
+++ b/languages/cbox.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 CUNY Academic Commons
+# Copyright (C) 2020 CUNY Academic Commons
 # This file is distributed under the same license as the Commons In A Box plugin.
 msgid ""
 msgstr ""
@@ -9,13 +9,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-08-29T14:44:40+00:00\n"
+"POT-Creation-Date: 2020-05-19T21:39:26-05:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.2.0-alpha\n"
+"X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: cbox\n"
 
 #. Plugin Name of the plugin
-#: admin/admin-loader.php:559
+#: admin/admin-loader.php:567
 msgid "Commons In A Box"
 msgstr ""
 
@@ -35,25 +35,907 @@ msgstr ""
 msgid "http://commons.gc.cuny.edu"
 msgstr ""
 
-#: includes/package.php:268
-msgid "Core Plugins"
+#: admin/admin-loader.php:320
+msgid "Installing Required Plugins"
 msgstr ""
 
-#: includes/package.php:269
-msgid "Optional Plugins"
+#: admin/admin-loader.php:328
+msgid "Continue to recommended plugins"
 msgstr ""
 
-#: includes/package.php:270
-msgid "Member Site Plugins"
+#: admin/admin-loader.php:335
+#: admin/admin-loader.php:392
+msgid "Continue to theme installation"
 msgstr ""
 
-#: includes/package.php:271
+#: admin/admin-loader.php:341
+msgid "Continue to dashboard"
+msgstr ""
+
+#: admin/admin-loader.php:356
+msgid "Confirm CBOX %s Installation"
+msgstr ""
+
+#: admin/admin-loader.php:367
+msgid "Return to dashboard"
+msgstr ""
+
+#: admin/admin-loader.php:369
+msgid "Install"
+msgstr ""
+
+#: admin/admin-loader.php:387
+msgid "Installing Selected Plugins"
+msgstr ""
+
+#: admin/admin-loader.php:395
+#: admin/admin-loader.php:427
+msgid "Continue to the CBOX Dashboard"
+msgstr ""
+
+#: admin/admin-loader.php:417
+msgid "Upgrading CBOX Plugins and Themes"
+msgstr ""
+
+#: admin/admin-loader.php:420
+msgid "Now, let's upgrade the %s theme &rarr;"
+msgstr ""
+
+#: admin/admin-loader.php:424
+msgid "Upgrading CBOX Plugins"
+msgstr ""
+
+#: admin/admin-loader.php:454
+msgid "Activate Theme"
+msgstr ""
+
+#: admin/admin-loader.php:456
+msgid "Install Theme"
+msgstr ""
+
+#: admin/admin-loader.php:461
+msgid "Return to package selection"
+msgstr ""
+
+#: admin/admin-loader.php:463
+msgid "Please note: This theme is <strong>required</strong> for use with Commons In A Box %s."
+msgstr ""
+
+#: admin/admin-loader.php:466
+msgid "Clicking on \"%1$s\" will change your current theme. If you do not wish to change the theme, please click \"%2$s\" and choose a different package."
+msgstr ""
+
+#: admin/admin-loader.php:471
+msgid "Skip"
+msgstr ""
+
+#: admin/admin-loader.php:474
+msgid "Please note: Clicking on \"%1$s\" will change your current theme.  If you would rather keep your existing theme, click on the \"%2$s\" link."
+msgstr ""
+
+#: admin/admin-loader.php:481
+msgid "Theme Installation"
+msgstr ""
+
+#: admin/admin-loader.php:504
+msgctxt "references the theme that is currently being installed"
+msgid "Installing %s theme"
+msgstr ""
+
+#: admin/admin-loader.php:519
+msgid "Upgrading Theme"
+msgstr ""
+
+#: admin/admin-loader.php:567
+msgid "CBOX %s"
+msgstr ""
+
+#: admin/admin-loader.php:580
+#: admin/admin-loader.php:632
+msgid "Commons In A Box Dashboard"
+msgstr ""
+
+#: admin/admin-loader.php:581
+#: includes/network-toolbar.php:1115
+#: lib/sidebar-funcs.php:309
+msgid "Dashboard"
+msgstr ""
+
+#: admin/admin-loader.php:682
+msgid "Select a Package"
+msgstr ""
+
+#: admin/admin-loader.php:684
+msgid "Commons In A Box includes two packages, each containing selected WordPress plugins and a WordPress theme. The packages are designed to make it easier for you to install and configure your site. Select the package that best suits your needs."
+msgstr ""
+
+#: admin/admin-loader.php:706
+msgid "Select %s"
+msgstr ""
+
+#: admin/admin-loader.php:706
+msgid "Select"
+msgstr ""
+
+#: admin/admin-loader.php:707
+msgid "More information about %s"
+msgstr ""
+
+#: admin/admin-loader.php:707
+msgid "More Details"
+msgstr ""
+
+#: admin/admin-loader.php:720
+msgid "Theme required; existing theme will be replaced during installation."
+msgstr ""
+
+#: admin/admin-loader.php:722
+msgid "Theme optional; theme installation can be skipped."
+msgstr ""
+
+#: admin/admin-loader.php:728
+msgid "Requires WordPress Multisite."
+msgstr ""
+
+#: admin/admin-loader.php:728
+msgid "Find out how to convert to a WordPress Multisite network here."
+msgstr ""
+
+#: admin/admin-loader.php:731
+msgid "<strong>Compatible</strong> with your version of WordPress"
+msgstr ""
+
+#: admin/admin-loader.php:752
+msgid "Required Plugins"
+msgstr ""
+
+#: admin/admin-loader.php:755
+msgid "Before you can use Commons In A Box %s, we'll need to install some required plugins. Click 'Continue' to get set up."
+msgstr ""
+
+#: admin/admin-loader.php:759
+msgid "Continue &rarr;"
+msgstr ""
+
+#: admin/admin-loader.php:769
+msgid "Recommended Plugins"
+msgstr ""
+
+#: admin/admin-loader.php:772
+msgid "You're almost finished with the installation process."
+msgstr ""
+
+#: admin/admin-loader.php:774
+msgid "Did you know Commons In A Box %s comes prebundled with a few recommended plugins?  These plugins help to add functionality to your existing WordPress site."
+msgstr ""
+
+#: admin/admin-loader.php:776
+msgid "We have automatically selected the following plugins to install for you. However, feel free to uncheck some of these plugins based on your site's needs."
+msgstr ""
+
+#: admin/admin-loader.php:785
+msgid "Continue"
+msgstr ""
+
+#: admin/admin-loader.php:836
+#: admin/admin-loader.php:912
+msgid "Upgrade Available"
+msgid_plural "Upgrades Available"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/admin-loader.php:840
+msgid "Commons In A Box %s requires WordPress %s"
+msgstr ""
+
+#: admin/admin-loader.php:842
+msgid "Upgrade now!"
+msgstr ""
+
+#: admin/admin-loader.php:896
+msgid "%d installed plugin and the theme have an update available. Click on the button below to upgrade."
+msgid_plural "%d installed plugins and the theme have updates available. Click on the button below to upgrade."
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/admin-loader.php:900
+msgid "%d installed plugin has an update available. Click on the button below to upgrade."
+msgid_plural "%d installed plugins have updates available. Click on the button below to upgrade."
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/admin-loader.php:907
+msgid "The %s theme has an update available. Click on the button below to upgrade."
+msgstr ""
+
+#: admin/admin-loader.php:918
+msgid "Upgrade"
+msgstr ""
+
+#: admin/admin-loader.php:1082
+msgid "Let's get started!"
+msgstr ""
+
+#: admin/admin-loader.php:1084
+msgid "Click here to get set up"
+msgstr ""
+
+#: admin/admin-loader.php:1089
+msgid "The %1$s theme needs an update."
+msgstr ""
+
+#: admin/admin-loader.php:1091
+msgid "Update the theme &rarr;"
+msgstr ""
+
+#: admin/admin-loader.php:1096
+msgid "You only have one last thing to do. We promise!"
+msgstr ""
+
+#: admin/admin-loader.php:1098
+msgid "Click here to finish up!"
+msgstr ""
+
+#: admin/admin-loader.php:1111
+msgid "Upgrading theme..."
+msgstr ""
+
+#: admin/admin-loader.php:1113
+msgid "Installing plugins..."
+msgstr ""
+
+#: admin/admin-loader.php:1121
+msgid "Commons In A Box is almost ready!"
+msgstr ""
+
+#: admin/admin-loader.php:1155
+msgid "CBOX Plugins"
+msgstr ""
+
+#: admin/admin-loader.php:1157
+msgid "CBOX Network Plugins"
+msgstr ""
+
+#: admin/admin-loader.php:1160
+msgid "Don't forget that CBOX plugins can be managed from the CBOX plugins page!"
+msgstr ""
+
+#: admin/admin-loader.php:1162
+msgid "You can <a href=\"%s\">manage your CBOX plugins here</a>."
+msgstr ""
+
+#: admin/admin-loader.php:1165
+msgid "Plugins on %s"
+msgstr ""
+
+#: admin/admin-loader.php:1167
+msgid "Other Network Plugins"
+msgstr ""
+
+#: admin/plugin-install.php:352
+msgid "Installing Plugin %1$s (%2$d/%3$d)"
+msgstr ""
+
+#: admin/plugin-install.php:354
+msgid "The installation process is starting. This process may take a while, so please be patient."
+msgstr ""
+
+#: admin/plugin-install.php:355
+msgid "An error occurred while installing %1$s: <strong>%2$s</strong>."
+msgstr ""
+
+#: admin/plugin-install.php:356
+msgid "The installation of %1$s failed."
+msgstr ""
+
+#: admin/plugin-install.php:357
+msgid "%1$s installed successfully."
+msgstr ""
+
+#: admin/plugin-install.php:357
+msgid "Show Details"
+msgstr ""
+
+#: admin/plugin-install.php:357
+msgid "Hide Details"
+msgstr ""
+
+#: admin/plugin-install.php:358
+msgid "Plugins finished installing."
+msgstr ""
+
+#: admin/plugin-install.php:385
+msgid "Plugins updated."
+msgstr ""
+
+#: admin/plugin-install.php:389
+msgid "Now Installing Plugins..."
+msgstr ""
+
+#: admin/plugin-install.php:404
+msgid "Now Activating Plugins..."
+msgstr ""
+
+#: admin/plugin-install.php:411
+#: admin/plugin-install.php:768
+msgid "Plugins activated."
+msgstr ""
+
+#: admin/plugin-install.php:507
+msgid "Continue to the CBOX dashboard"
+msgstr ""
+
+#: admin/plugin-install.php:514
+msgid "Return to the CBOX Plugins page"
+msgstr ""
+
+#: admin/plugin-install.php:729
+msgid "Upgrading Existing Plugins..."
+msgstr ""
+
+#: admin/plugin-install.php:750
+msgid "Installing Plugins..."
+msgstr ""
+
+#: admin/plugin-install.php:763
+msgid "Activating Plugins..."
+msgstr ""
+
+#: admin/plugins.php:384
+msgid "Commons In A Box Plugins"
+msgstr ""
+
+#: admin/plugins.php:385
+#: admin/templates/base/package-details.php:13
+#: admin/templates/openlab/getting-started.php:12
+#: admin/templates/openlab/package-details.php:7
+msgid "Plugins"
+msgstr ""
+
+#: admin/plugins.php:428
+msgid "You do not have sufficient permissions to deactivate plugins for this site."
+msgstr ""
+
+#: admin/plugins.php:570
+msgid "Plugin deactivated."
+msgstr ""
+
+#: admin/plugins.php:582
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:507
+msgid "The following plugins have also been deactivated:"
+msgstr ""
+
+#: admin/plugins.php:618
+msgid "Plugin uninstalled."
+msgstr ""
+
+#: admin/plugins.php:626
+msgid "Plugin network-deactivated."
+msgstr ""
+
+#: admin/plugins.php:652
+#: admin/plugins.php:664
+#: admin/plugins.php:821
+#: includes/admin.php:160
+msgid "Update"
+msgstr ""
+
+#: admin/plugins.php:658
+#: buddypress/members/activate.php:48
+msgid "Activate"
+msgstr ""
+
+#: admin/plugins.php:669
+msgid "%1$s Plugins: %2$s"
+msgstr ""
+
+#: admin/plugins.php:704
+msgid "This plugin might be active on other member sites.  If so, removing the plugin will remove this functionality on those sites."
+msgstr ""
+
+#: admin/plugins.php:705
+msgid "Are you sure you want to continue uninstalling?"
+msgstr ""
+
+#: admin/plugins.php:727
+#: buddypress/groups/single/admin.php:60
+msgid "No"
+msgstr ""
+
+#: admin/plugins.php:731
+#: buddypress/groups/single/admin.php:59
+msgid "Yes"
+msgstr ""
+
+#: admin/plugins.php:774
+msgid "Update CBOX"
+msgstr ""
+
+#: admin/plugins.php:833
+#: admin/plugins.php:841
+msgid "Select all"
+msgstr ""
+
+#: admin/plugins.php:834
+#: admin/plugins.php:842
+msgid "Plugin"
+msgstr ""
+
+#: admin/plugins.php:835
+#: admin/plugins.php:843
+#: buddypress/groups/create.php:154
+#: buddypress/groups/single/admin.php:50
+#: buddypress/groups/single/group-home.php:181
+msgid "Description"
+msgstr ""
+
+#: admin/plugins.php:867
+msgid "Plugin is already installed"
+msgstr ""
+
+#: admin/plugins.php:870
+msgid "Check this box to install the plugin."
+msgstr ""
+
+#: admin/plugins.php:873
+msgid "Plugin is already active!"
+msgstr ""
+
+#: admin/plugins.php:897
+#: admin/templates/classic/getting-started.php:18
+msgid "Click here to view this plugin's settings page"
+msgstr ""
+
+#: admin/plugins.php:899
+#: admin/templates/classic/getting-started.php:11
+#: includes/classic/settings.php:165
+#: buddypress/docs/single/edit.php:108
+#: lib/menus.php:1012
+#: lib/menus.php:1030
+msgid "Settings"
+msgstr ""
+
+#: admin/plugins.php:907
+msgid "Click here for documentation on this plugin, from commonsinabox.org"
+msgstr ""
+
+#: admin/plugins.php:909
+msgid "Info"
+msgstr ""
+
+#: admin/plugins.php:917
+msgid "Deactivate this plugin."
+msgstr ""
+
+#: admin/plugins.php:919
+msgid "Deactivate"
+msgstr ""
+
+#: admin/plugins.php:927
+msgid "Uninstall %s"
+msgstr ""
+
+#: admin/plugins.php:929
+msgid "Uninstall"
+msgstr ""
+
+#: admin/plugins.php:939
+msgid "Select the checkbox and click on 'Update' to upgrade this plugin."
+msgstr ""
+
+#: admin/plugins.php:939
+msgid "Update available."
+msgstr ""
+
+#: admin/plugins.php:956
+msgid "Requires: "
+msgstr ""
+
+#: admin/plugins.php:966
+msgid "(enabled)"
+msgstr ""
+
+#: admin/plugins.php:968
+msgid "(disabled)"
+msgstr ""
+
+#: admin/plugins.php:970
+msgid "(automatically installed with %s)"
+msgstr ""
+
+#: admin/plugins.php:988
+msgid "%1$s is network-activated, but we recommend only activating this plugin on the main site."
+msgstr ""
+
+#: admin/plugins.php:992
+msgid "(Change)"
+msgstr ""
+
+#: admin/templates/base/footer.php:4
+msgid "Change packages"
+msgstr ""
+
+#: admin/templates/base/package-details-intro.php:4
+msgid "Welcome to CBOX %1$s! If this is a new WordPress Multisite installation, just click Install to continue. If you are adding CBOX %1$s to an existing installation, please consult the <a href=\"%2$s\">documentation</a> before continuing."
+msgstr ""
+
+#: admin/templates/base/package-details-intro.php:8
+msgid "Welcome to CBOX %1$s! If this is a new WordPress installation, just click Install to continue. If you are adding CBOX %1$s to an existing installation, please consult the <a href=\"%2$s\">documentation</a> before continuing."
+msgstr ""
+
+#: admin/templates/base/package-details-plugins.php:2
+msgid "CBOX %s will install and activate plugins that you do not already have installed."
+msgstr ""
+
+#: admin/templates/base/package-details-theme.php:2
+msgid "The CBOX %s theme will change how your site looks, and will alter its architecture. Any widgets or menus that you currently have set will need to be reconfigured under the Appearance menu in the Dashboard."
+msgstr ""
+
+#: admin/templates/base/package-details.php:5
+#: admin/templates/base/theme-prompt.php:3
+#: admin/templates/openlab/package-details.php:2
+msgid "Screenshot of theme"
+msgstr ""
+
+#: admin/templates/base/package-details.php:8
+#: admin/templates/classic/getting-started.php:37
+#: admin/templates/openlab/package-details.php:4
+msgid "Theme"
+msgstr ""
+
+#: admin/templates/base/plugins-install-only-header.php:2
+msgid "The following plugins can improve the WordPress site experience for your users."
+msgstr ""
+
+#: admin/templates/base/plugins-install-only-header.php:3
+msgid "Installing a plugin here makes it available for members in the Plugins area of their site."
+msgstr ""
+
+#: admin/templates/base/plugins-install-only-header.php:4
+msgid "If you would like to add or manage other plugins for your members to access, you can access that area <a href=\"%s\">here</a>."
+msgstr ""
+
+#: admin/templates/base/plugins-install-only-header.php:5
+msgid "To install, check the plugins you want to install and click 'Install'."
+msgstr ""
+
+#: admin/templates/base/plugins-optional-header.php:2
+msgid "The following plugins work well with Commons In A Box %s, but they require a bit of additional setup, so we do not install them by default."
+msgstr ""
+
+#: admin/templates/base/plugins-optional-header.php:3
+#: admin/templates/openlab/plugins-optional-header.php:3
+msgid "To install, check the plugins you want to install and click 'Activate'."
+msgstr ""
+
+#: admin/templates/base/plugins-recommended-header.php:1
+msgid "Recommended"
+msgstr ""
+
+#: admin/templates/base/plugins-recommended-header.php:3
+msgid "The following plugins are recommended during initial Commons In A Box %s setup.  We like them, but feel free to deactivate them if you don't need certain functionality."
+msgstr ""
+
+#: admin/templates/base/plugins-required-header.php:1
+msgid "To update, check the plugins you want to update and click 'Update'."
+msgstr ""
+
+#: admin/templates/base/plugins-required-header.php:3
+#: includes/admin.php:141
+msgid "Required"
+msgstr ""
+
+#: admin/templates/base/plugins-required-header.php:5
+msgid "Commons In A Box %s requires the following plugins."
+msgstr ""
+
+#: admin/templates/base/theme-prompt.php:6
+msgid "One last step!"
+msgstr ""
+
+#: admin/templates/base/theme-prompt.php:8
+msgid "The %1$s Theme is the final piece of the Commons In A Box %2$s experience."
+msgstr ""
+
+#: admin/templates/base/welcome.php:6
+#: admin/templates/classic/changelog.php:8
+#: admin/templates/openlab/changelog.php:8
+msgid "Badge"
+msgstr ""
+
+#: admin/templates/base/welcome.php:8
+msgid "Version %s"
+msgstr ""
+
 #: admin/templates/classic/changelog.php:3
+#: includes/package.php:271
 msgid "Welcome to Commons In A Box %s"
 msgstr ""
 
-#: includes/frontend-wp.php:86
-msgid "Updates available."
+#: admin/templates/classic/changelog.php:5
+#: admin/templates/openlab/changelog.php:5
+msgid "Thank you for updating to the latest version!"
+msgstr ""
+
+#: admin/templates/classic/changelog.php:13
+#: admin/templates/openlab/changelog.php:13
+msgid "What&#8217;s New"
+msgstr ""
+
+#: admin/templates/classic/changelog.php:16
+#: admin/templates/classic/welcome-description.php:7
+#: admin/templates/openlab/changelog.php:16
+#: admin/templates/openlab/welcome-description.php:7
+msgid "Credits"
+msgstr ""
+
+#: admin/templates/classic/changelog.php:21
+#: admin/templates/openlab/changelog.php:21
+msgid "Under the Hood"
+msgstr ""
+
+#: admin/templates/classic/changelog.php:27
+msgid "Improved compatibility with BP Customizer settings when using the Nouveau template pack."
+msgstr ""
+
+#: admin/templates/classic/changelog.php:28
+#: admin/templates/openlab/changelog.php:29
+msgid "Improvements to the behavior of network-activated CBOX plugins."
+msgstr ""
+
+#: admin/templates/classic/changelog.php:29
+#: admin/templates/openlab/changelog.php:30
+msgid "Fixed bug in WP-CLI tools that caused theme update to unzip to wrong location in some cases."
+msgstr ""
+
+#: admin/templates/classic/changelog.php:30
+#: admin/templates/openlab/changelog.php:31
+msgid "Improved compatibility with Multi-Network setups."
+msgstr ""
+
+#: admin/templates/classic/changelog.php:37
+#: admin/templates/openlab/changelog.php:38
+msgid "Plugin Updates"
+msgstr ""
+
+#: admin/templates/classic/changelog.php:47
+#: admin/templates/openlab/changelog.php:48
+msgid "Theme Updates"
+msgstr ""
+
+#: admin/templates/classic/changelog.php:51
+msgid "Fixed an issue with making searches on BuddyPress directory pages."
+msgstr ""
+
+#: admin/templates/classic/changelog.php:52
+msgid "Fixed a bug with tab navigation in CBOX Theme options."
+msgstr ""
+
+#: admin/templates/classic/changelog.php:58
+#: admin/templates/openlab/changelog.php:61
+msgid "<a href=\"%s\">Return to the CBOX dashboard &rarr;</a>"
+msgstr ""
+
+#: admin/templates/classic/description.php:2
+msgid "<strong>CBOX Classic is designed for communities of all kinds.</strong> It is used by groups and organizations to create flexible social networks where members can collaborate on projects, publish research, and create repositories of knowledge."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:3
+msgid "Getting Started with Commons in A Box Classic"
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:12
+msgid "Commons In A Box works by pulling together a number of independent WordPress and BuddyPress plugins. Customize your site by exploring the settings pages for these plugins below."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:21
+msgid "Click here for plugin documentation at commonsinabox.org"
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:21
+msgid "Info..."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:30
+msgid "<a href=\"%s\">Manage all your CBOX plugins here</a>"
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:43
+msgid "<a href=\"%1$s\">Install the %2$s theme to get started</a>."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:52
+msgid "Your current theme is %s."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:57
+msgid "It looks like this theme is not compatible with BuddyPress."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:64
+msgid "Did you know that <strong>%s</strong> comes with a cool theme? Check it out below!"
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:66
+msgid "Screenshot of the %s theme"
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:70
+msgid "<a href=\"%1$s\">Like the %2$s theme? Install it!</a>"
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:79
+msgid "You can also make your theme compatible with the <a href='%s'>BuddyPress Template Pack</a>."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:90
+msgid "You're using a child theme of the <strong>%1$s</strong> theme."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:92
+msgid "You're using the <strong>%1$s</strong> theme."
+msgstr ""
+
+#: admin/templates/classic/getting-started.php:97
+msgid "<a href=\"%1$s\">Configure the %2$s theme here</a>"
+msgstr ""
+
+#: admin/templates/classic/package-details-plugins.php:2
+msgid "The CBOX Classic package includes several required plugins that provide important features such as groups, user profiles, discussion forums, collaborative document editing, and other functionality. These plugins may interact with any existing plugins you have installed."
+msgstr ""
+
+#: admin/templates/classic/welcome-description.php:1
+msgid "CBOX Classic is designed for communities of all kinds. It is used by groups and organizations to create flexible social networks where members can collaborate on projects, publish research, and create repositories of knowledge."
+msgstr ""
+
+#: admin/templates/classic/welcome-description.php:3
+msgid "Commons In A Box was made possible by a generous grant from the <a href=\"%1$s\" target=\"_blank\">Alfred P. Sloan Foundation</a> that allowed us to turn the infrastructure that successfully powers the <a href=\"%2$s\" target=\"_blank\">CUNY Academic Commons</a> into a distributable, easy-to-install package."
+msgstr ""
+
+#: admin/templates/classic/welcome-description.php:6
+#: admin/templates/openlab/welcome-description.php:6
+msgid "What's New"
+msgstr ""
+
+#: admin/templates/classic/welcome-description.php:8
+#: admin/templates/openlab/welcome-description.php:8
+msgid "Documentation"
+msgstr ""
+
+#: admin/templates/openlab/changelog.php:3
+msgid "Welcome to Commons In A Box OpenLab %s"
+msgstr ""
+
+#: admin/templates/openlab/changelog.php:27
+msgid "Hide \"Group Home\" link from site navs when the group is inaccessible to current user."
+msgstr ""
+
+#: admin/templates/openlab/changelog.php:28
+msgid "Fix bug that could prevent site admins from accessing Dashboard > Plugins in some cases."
+msgstr ""
+
+#: admin/templates/openlab/changelog.php:52
+msgid "Fixed bug with BuddyPress Docs edit mode."
+msgstr ""
+
+#: admin/templates/openlab/changelog.php:53
+msgid "Improved appearance of single page/post content."
+msgstr ""
+
+#: admin/templates/openlab/changelog.php:54
+msgid "Fixed incorrect \"Recent Docs\" and \"Recent Discussions\" subheaders when WordPress is installed in a subdirectory."
+msgstr ""
+
+#: admin/templates/openlab/changelog.php:55
+msgid "Improved language regarding \"Professor(s)\" in group headers."
+msgstr ""
+
+#: admin/templates/openlab/description.php:2
+msgid "<strong>New! CBOX OpenLab is specifically designed for teaching, learning, and collaboration</strong>. It allows faculty members, departments, and entire institutions to create commons spaces for open learning."
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:4
+msgid "Getting Started with Commons in A Box OpenLab"
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:8
+msgid "We've assembled some links to get you started. Check out our <a href=\"%1$s\" target=\"_blank\">documentation</a> for detailed instructions. Questions? Post them on our <a href=\"%2$s\" target=\"_blank\">CBOX OpenLab Support Forum</a>."
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:13
+msgid "Manage Community Feature plugins for your site and Member Site Plugins that you would like to make available to your members for their individual WordPress sites."
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:16
+#: includes/admin.php:31
+#: includes/admin.php:32
+#: includes/admin.php:199
+msgid "Member Settings"
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:17
+msgid "Modify member categories, their capabilities and permissions, who can create an account, and what types of accounts different members can create. These settings also include email domain whitelisting and registration codes to restrict access by account type."
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:20
+#: includes/admin.php:41
+#: includes/admin.php:42
+#: includes/admin.php:202
+msgid "Group Settings"
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:21
+msgid "Affect the appearance and functionality of groups across your site. You can change the features and site templates available to groups, as well as create and assign categories for groups that can be used to filter items on the group directory pages."
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:24
+#: includes/admin.php:51
+#: includes/admin.php:52
+#: includes/admin.php:211
+#: lib/group-funcs.php:2518
+msgid "Academic Units"
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:25
+msgid "Create unit-types that best describe how your institution is organized &ndash; for example, Departments that are located within Divisions &ndash; and define the units within each type. These units can be utilized as filters across your site's groups and for members to associate themselves in their profiles."
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:28
+#: includes/admin.php:61
+#: includes/admin.php:62
+#: includes/admin.php:205
+msgid "Brand Settings"
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:29
+msgid "Customize your site including color scheme, logo, homepage layout, footer content, and widgets."
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:32
+#: includes/admin.php:71
+#: includes/admin.php:72
+#: includes/admin.php:208
+msgid "Communication Settings"
+msgstr ""
+
+#: admin/templates/openlab/getting-started.php:33
+msgid "Manage email and other communication settings, including email template content and appearance and group email subscription settings."
+msgstr ""
+
+#: admin/templates/openlab/package-details.php:5
+msgid "The CBOX OpenLab theme will change how your site looks, and will alter its architecture."
+msgstr ""
+
+#: admin/templates/openlab/package-details.php:8
+msgid "The CBOX OpenLab package includes several required plugins that provide important features such as groups, user profiles, discussion forums, collaborative document editing, and other functionality. These plugins may interact with any existing plugins you have installed."
+msgstr ""
+
+#: admin/templates/openlab/plugins-optional-header.php:2
+msgid "The following plugins influence the community aspects of your site, but they require a bit of additional setup, so we do not install them by default."
+msgstr ""
+
+#: admin/templates/openlab/welcome-description.php:1
+msgid "Commons In A Box OpenLab is designed for teaching, learning, and collaboration. It allows faculty members, departments, and entire institutions to create commons spaces for open learning."
+msgstr ""
+
+#: admin/templates/openlab/welcome-description.php:3
+msgid "Commons In A Box OpenLab is a collaboration between <a href=\"%1$s\" target=\"_blank\">The Graduate Center, CUNY</a> and <a href=\"%2$s\" target=\"_blank\">New York City College of Technology</a>. It is being created with funding from the National Endowment for the Humanities' <a href=\"%3$s\" target=\"_blank\">Office of Digital Humanities</a>."
+msgstr ""
+
+#: admin/theme-install.php:205
+msgid "Continue to CBOX Dashboard &rarr;"
+msgstr ""
+
+#: includes/classic/defaults/bbpress.php:48
+#: includes/classic/defaults/bbpress.php:56
+#: includes/openlab/defaults/bbpress.php:48
+#: includes/openlab/defaults/bbpress.php:56
+msgid "Group Forums"
+msgstr ""
+
+#: includes/classic/defaults/bbpress.php:57
+#: includes/openlab/defaults/bbpress.php:57
+msgid "All forums created in groups can be found here."
 msgstr ""
 
 #: includes/classic/plugins.php:42
@@ -67,6 +949,7 @@ msgid "BuddyPress provides the core functionality of Commons In A Box, including
 msgstr ""
 
 #: includes/classic/plugins.php:81
+#: includes/frontend-adminbar-bpdocs.php:7
 #: includes/openlab/plugins.php:79
 msgid "Docs"
 msgstr ""
@@ -96,6 +979,7 @@ msgstr ""
 
 #: includes/classic/plugins.php:124
 #: includes/openlab/plugins.php:147
+#: includes/communication-settings.php:58
 msgid "Invite Anyone"
 msgstr ""
 
@@ -171,12 +1055,12 @@ msgid "Gives group creators and administrators the ability to attach external RS
 msgstr ""
 
 #: includes/classic/plugins.php:254
-#: includes/openlab/plugins.php:258
+#: includes/openlab/plugins.php:267
 msgid "Reply By Email"
 msgstr ""
 
 #: includes/classic/plugins.php:255
-#: includes/openlab/plugins.php:259
+#: includes/openlab/plugins.php:268
 msgid "Reply to content from all over the community from the comfort of your email inbox"
 msgstr ""
 
@@ -205,31 +1089,118 @@ msgid "Check this box if you would like the full text of bbPress forum posts to 
 msgstr ""
 
 #: includes/classic/settings.php:164
-#: includes/classic/settings.php:210
+#: includes/classic/settings.php:207
 msgid "Commons In A Box Settings"
 msgstr ""
 
-#: includes/classic/settings.php:165
-#: admin/plugins.php:899
-#: admin/templates/classic/getting-started.php:11
-msgid "Settings"
-msgstr ""
-
-#: includes/classic/settings.php:200
+#: includes/classic/settings.php:197
 msgid "Settings saved."
 msgstr ""
 
-#: includes/classic/settings.php:212
+#: includes/classic/settings.php:209
 msgid "CBOX can configure some important options for certain plugins."
 msgstr ""
 
-#: includes/classic/settings.php:219
+#: includes/classic/settings.php:216
+#: includes/admin.php:143
+#: buddypress/groups/single/admin.php:76
+#: buddypress/groups/single/admin.php:200
+#: buddypress/groups/single/admin.php:212
+#: buddypress/members/single/profile/edit.php:194
+#: buddypress/members/single/settings/general.php:79
+#: buddypress/members/single/settings/notifications.php:28
+#: lib/group-funcs.php:1030
 msgid "Save Changes"
 msgstr ""
 
-#: includes/classic/defaults/bbpress.php:57
-#: includes/openlab/defaults/bbpress.php:57
-msgid "All forums created in groups can be found here."
+#: includes/frontend-adminbar-bbpress.php:42
+msgid "Forums"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:50
+msgid "Topics Started"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:58
+msgid "Replies Created"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:67
+msgid "Engagements"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:77
+msgid "Favorite Topics"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:87
+msgid "Subscribed Topics"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:127
+msgid "Topic Replies"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:140
+msgid "a forum topic"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:145
+msgid "You have %d new replies"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:148
+msgid "You have %d new reply to %2$s from %3$s"
+msgstr ""
+
+#: includes/frontend-adminbar-bbpress.php:150
+msgid "You have %d new reply to %s"
+msgstr ""
+
+#: includes/frontend-adminbar-bpdocs.php:35
+msgid "Started By Me"
+msgstr ""
+
+#: includes/frontend-adminbar-bpdocs.php:42
+msgid "Edited By Me"
+msgstr ""
+
+#: includes/frontend-adminbar-bpdocs.php:49
+msgid "Create New Doc"
+msgstr ""
+
+#: includes/frontend-adminbar-bpeo.php:15
+#: includes/openlab/plugins.php:245
+msgid "Events"
+msgstr ""
+
+#: includes/frontend-adminbar-bpeo.php:22
+#: classes/Install.php:981
+#: lib/core/page-control.php:62
+#: lib/menus.php:45
+#: lib/menus.php:65
+msgid "Calendar"
+msgstr ""
+
+#: includes/frontend-adminbar-bpeo.php:29
+msgid "New Event"
+msgstr ""
+
+#: includes/frontend-bbpress.php:323
+msgid "Your forum post is pending moderation"
+msgstr ""
+
+#: includes/frontend-bp.php:126
+#: includes/frontend-bp.php:132
+msgid "Activity"
+msgstr ""
+
+#: includes/frontend-wp.php:86
+msgid "Updates available."
+msgstr ""
+
+#: includes/openlab/openlab.php:54
+msgid "Community Features"
 msgstr ""
 
 #: includes/openlab/plugins.php:55
@@ -256,888 +1227,5656 @@ msgstr ""
 msgid "Allow your members to attach documents to groups."
 msgstr ""
 
-#: includes/openlab/plugins.php:236
-msgid "Events"
+#: includes/openlab/plugins.php:182
+#: classes/Install.php:451
+msgid "Portfolio"
 msgstr ""
 
-#: includes/openlab/plugins.php:237
+#: includes/openlab/plugins.php:183
+msgid "WordPress portfolio tools."
+msgstr ""
+
+#: includes/openlab/plugins.php:246
 msgid "Allows your members to create a calendar for themselves and to attach specific events to groups."
 msgstr ""
 
-#: includes/openlab/plugins.php:272
+#: includes/openlab/plugins.php:281
 msgid "Braille Support"
 msgstr ""
 
-#: includes/openlab/plugins.php:273
+#: includes/openlab/plugins.php:282
 msgid "An addon for the Braille plugin providing support for BuddyPress Group Forums and Private Messaging"
 msgstr ""
 
-#: includes/openlab/plugins.php:293
+#: includes/openlab/plugins.php:302
 msgid "Anthologize"
 msgstr ""
 
-#: includes/openlab/plugins.php:294
+#: includes/openlab/plugins.php:303
 msgid "Create ebooks from your blog posts or other external content."
 msgstr ""
 
-#: includes/openlab/plugins.php:303
+#: includes/openlab/plugins.php:312
 msgid "Braille"
 msgstr ""
 
-#: includes/openlab/plugins.php:304
+#: includes/openlab/plugins.php:313
 msgid "Provides a number of Braille-related services to WordPress."
 msgstr ""
 
-#: includes/openlab/plugins.php:311
+#: includes/openlab/plugins.php:320
 msgid "PressForward"
 msgstr ""
 
-#: includes/openlab/plugins.php:312
+#: includes/openlab/plugins.php:321
 msgid "A plugin providing an editorial workflow for content aggregation and curation within the WordPress dashboard. Designed for bloggers and editorial teams wishing to collect, discuss, and share content from a variety of sources on the open web."
 msgstr ""
 
-#: includes/openlab/plugins.php:321
+#: includes/openlab/plugins.php:330
 msgid "WP Grade Comments"
 msgstr ""
 
-#: includes/openlab/plugins.php:322
+#: includes/openlab/plugins.php:331
 msgid "A plugin for instructors using their WordPress site in a course setting. Provides ability to give private feedback and/or grades to post authors, all without leaving the familiar commenting interface."
 msgstr ""
 
-#: includes/openlab/openlab.php:54
-msgid "Community Features"
+#: includes/package.php:268
+msgid "Core Plugins"
 msgstr ""
 
-#: admin/plugin-install.php:352
-msgid "Installing Plugin %1$s (%2$d/%3$d)"
+#: includes/package.php:269
+msgid "Optional Plugins"
 msgstr ""
 
-#: admin/plugin-install.php:354
-msgid "The installation process is starting. This process may take a while, so please be patient."
+#: includes/package.php:270
+msgid "Member Site Plugins"
 msgstr ""
 
-#: admin/plugin-install.php:355
-msgid "An error occurred while installing %1$s: <strong>%2$s</strong>."
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:508
+msgid "The following plugins have been deactivated due to dependency conflicts:"
 msgstr ""
 
-#: admin/plugin-install.php:356
-msgid "The installation of %1$s failed."
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:556
+msgid "Pre-activation warnings"
 msgstr ""
 
-#: admin/plugin-install.php:357
-msgid "%1$s installed successfully."
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:559
+msgid "%s requires the following issues to be addressed before it can be activated: "
 msgstr ""
 
-#: admin/plugin-install.php:357
-msgid "Show Details"
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:568
+msgid "Unactivated plugin"
 msgstr ""
 
-#: admin/plugin-install.php:357
-msgid "Hide Details"
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:572
+msgid "(Activate it now!)"
 msgstr ""
 
-#: admin/plugin-install.php:358
-msgid "Plugins finished installing."
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:580
+msgid "Missing plugin"
 msgstr ""
 
-#: admin/plugin-install.php:385
-msgid "Plugins updated."
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:582
+msgid "(<a href=\"%s\">Try to find the plugin and install it here</a>)"
 msgstr ""
 
-#: admin/plugin-install.php:389
-msgid "Now Installing Plugins..."
-msgstr ""
-
-#: admin/plugin-install.php:404
-msgid "Now Activating Plugins..."
-msgstr ""
-
-#: admin/plugin-install.php:411
-#: admin/plugin-install.php:768
-msgid "Plugins activated."
-msgstr ""
-
-#: admin/plugin-install.php:507
-msgid "Continue to the CBOX dashboard"
-msgstr ""
-
-#: admin/plugin-install.php:514
-msgid "Return to the CBOX Plugins page"
-msgstr ""
-
-#: admin/plugin-install.php:729
-msgid "Upgrading Existing Plugins..."
-msgstr ""
-
-#: admin/plugin-install.php:750
-msgid "Installing Plugins..."
-msgstr ""
-
-#: admin/plugin-install.php:763
-msgid "Activating Plugins..."
-msgstr ""
-
-#: admin/admin-loader.php:320
-msgid "Installing Required Plugins"
-msgstr ""
-
-#: admin/admin-loader.php:327
-msgid "Continue to recommended plugins"
-msgstr ""
-
-#: admin/admin-loader.php:334
-#: admin/admin-loader.php:384
-msgid "Continue to theme installation"
-msgstr ""
-
-#: admin/admin-loader.php:348
-msgid "Confirm CBOX %s Installation"
-msgstr ""
-
-#: admin/admin-loader.php:359
-msgid "Return to dashboard"
-msgstr ""
-
-#: admin/admin-loader.php:361
-msgid "Install"
-msgstr ""
-
-#: admin/admin-loader.php:379
-msgid "Installing Selected Plugins"
-msgstr ""
-
-#: admin/admin-loader.php:387
-#: admin/admin-loader.php:419
-msgid "Continue to the CBOX Dashboard"
-msgstr ""
-
-#: admin/admin-loader.php:409
-msgid "Upgrading CBOX Plugins and Themes"
-msgstr ""
-
-#: admin/admin-loader.php:412
-msgid "Now, let's upgrade the %s theme &rarr;"
-msgstr ""
-
-#: admin/admin-loader.php:416
-msgid "Upgrading CBOX Plugins"
-msgstr ""
-
-#: admin/admin-loader.php:446
-msgid "Activate Theme"
-msgstr ""
-
-#: admin/admin-loader.php:448
-msgid "Install Theme"
-msgstr ""
-
-#: admin/admin-loader.php:453
-msgid "Return to package selection"
-msgstr ""
-
-#: admin/admin-loader.php:455
-msgid "Please note: This theme is <strong>required</strong> for use with Commons In A Box %s."
-msgstr ""
-
-#: admin/admin-loader.php:458
-msgid "Clicking on \"%1$s\" will change your current theme. If you do not wish to change the theme, please click \"%2$s\" and choose a different package."
-msgstr ""
-
-#: admin/admin-loader.php:463
-msgid "Skip"
-msgstr ""
-
-#: admin/admin-loader.php:466
-msgid "Please note: Clicking on \"%1$s\" will change your current theme.  If you would rather keep your existing theme, click on the \"%2$s\" link."
-msgstr ""
-
-#: admin/admin-loader.php:473
-msgid "Theme Installation"
-msgstr ""
-
-#: admin/admin-loader.php:496
-msgctxt "references the theme that is currently being installed"
-msgid "Installing %s theme"
-msgstr ""
-
-#: admin/admin-loader.php:511
-msgid "Upgrading Theme"
-msgstr ""
-
-#: admin/admin-loader.php:559
-msgid "CBOX %s"
-msgstr ""
-
-#: admin/admin-loader.php:572
-#: admin/admin-loader.php:627
-msgid "Commons In A Box Dashboard"
-msgstr ""
-
-#: admin/admin-loader.php:573
-msgid "Dashboard"
-msgstr ""
-
-#: admin/admin-loader.php:677
-msgid "Select a Package"
-msgstr ""
-
-#: admin/admin-loader.php:679
-msgid "Commons In A Box includes two packages, each containing selected WordPress plugins and a WordPress theme. The packages are designed to make it easier for you to install and configure your site. Select the package that best suits your needs."
-msgstr ""
-
-#: admin/admin-loader.php:701
-msgid "Select %s"
-msgstr ""
-
-#: admin/admin-loader.php:701
-msgid "Select"
-msgstr ""
-
-#: admin/admin-loader.php:702
-msgid "More information about %s"
-msgstr ""
-
-#: admin/admin-loader.php:702
-msgid "More Details"
-msgstr ""
-
-#: admin/admin-loader.php:715
-msgid "Theme required; existing theme will be replaced during installation."
-msgstr ""
-
-#: admin/admin-loader.php:717
-msgid "Theme optional; theme installation can be skipped."
-msgstr ""
-
-#: admin/admin-loader.php:723
-msgid "Requires WordPress Multisite."
-msgstr ""
-
-#: admin/admin-loader.php:723
-msgid "Find out how to convert to a WordPress Multisite network here."
-msgstr ""
-
-#: admin/admin-loader.php:726
-msgid "<strong>Compatible</strong> with your version of WordPress"
-msgstr ""
-
-#: admin/admin-loader.php:747
-msgid "Required Plugins"
-msgstr ""
-
-#: admin/admin-loader.php:750
-msgid "Before you can use Commons In A Box %s, we'll need to install some required plugins. Click 'Continue' to get set up."
-msgstr ""
-
-#: admin/admin-loader.php:754
-msgid "Continue &rarr;"
-msgstr ""
-
-#: admin/admin-loader.php:764
-msgid "Recommended Plugins"
-msgstr ""
-
-#: admin/admin-loader.php:767
-msgid "You're almost finished with the installation process."
-msgstr ""
-
-#: admin/admin-loader.php:769
-msgid "Did you know Commons In A Box %s comes prebundled with a few recommended plugins?  These plugins help to add functionality to your existing WordPress site."
-msgstr ""
-
-#: admin/admin-loader.php:771
-msgid "We have automatically selected the following plugins to install for you. However, feel free to uncheck some of these plugins based on your site's needs."
-msgstr ""
-
-#: admin/admin-loader.php:780
-msgid "Continue"
-msgstr ""
-
-#: admin/admin-loader.php:831
-#: admin/admin-loader.php:907
-msgid "Upgrade Available"
-msgid_plural "Upgrades Available"
-msgstr[0] ""
-
-#: admin/admin-loader.php:835
-msgid "Commons In A Box %s requires WordPress %s"
-msgstr ""
-
-#: admin/admin-loader.php:837
-msgid "Upgrade now!"
-msgstr ""
-
-#: admin/admin-loader.php:891
-msgid "%d installed plugin and the theme have an update available. Click on the button below to upgrade."
-msgid_plural "%d installed plugins and the theme have updates available. Click on the button below to upgrade."
-msgstr[0] ""
-
-#: admin/admin-loader.php:895
-msgid "%d installed plugin has an update available. Click on the button below to upgrade."
-msgid_plural "%d installed plugins have updates available. Click on the button below to upgrade."
-msgstr[0] ""
-
-#: admin/admin-loader.php:902
-msgid "The %s theme has an update available. Click on the button below to upgrade."
-msgstr ""
-
-#: admin/admin-loader.php:913
-msgid "Upgrade"
-msgstr ""
-
-#: admin/admin-loader.php:1077
-msgid "Let's get started!"
-msgstr ""
-
-#: admin/admin-loader.php:1079
-msgid "Click here to get set up"
-msgstr ""
-
-#: admin/admin-loader.php:1084
-msgid "The %1$s theme needs an update."
-msgstr ""
-
-#: admin/admin-loader.php:1086
-msgid "Update the theme &rarr;"
-msgstr ""
-
-#: admin/admin-loader.php:1091
-msgid "You only have one last thing to do. We promise!"
-msgstr ""
-
-#: admin/admin-loader.php:1093
-msgid "Click here to finish up!"
-msgstr ""
-
-#: admin/admin-loader.php:1106
-msgid "Upgrading theme..."
-msgstr ""
-
-#: admin/admin-loader.php:1108
-msgid "Installing plugins..."
-msgstr ""
-
-#: admin/admin-loader.php:1116
-msgid "Commons In A Box is almost ready!"
-msgstr ""
-
-#: admin/admin-loader.php:1150
-msgid "CBOX Plugins"
-msgstr ""
-
-#: admin/admin-loader.php:1152
-msgid "CBOX Network Plugins"
-msgstr ""
-
-#: admin/admin-loader.php:1155
-msgid "Don't forget that CBOX plugins can be managed from the CBOX plugins page!"
-msgstr ""
-
-#: admin/admin-loader.php:1157
-msgid "You can <a href=\"%s\">manage your CBOX plugins here</a>."
-msgstr ""
-
-#: admin/admin-loader.php:1160
-msgid "Plugins on %s"
-msgstr ""
-
-#: admin/admin-loader.php:1162
-msgid "Other Network Plugins"
-msgstr ""
-
-#: admin/plugins.php:384
-msgid "Commons In A Box Plugins"
-msgstr ""
-
-#: admin/plugins.php:385
-#: admin/templates/base/package-details.php:13
-#: admin/templates/openlab/package-details.php:7
-#: admin/templates/openlab/getting-started.php:12
-msgid "Plugins"
-msgstr ""
-
-#: admin/plugins.php:570
-msgid "Plugin deactivated."
-msgstr ""
-
-#: admin/plugins.php:582
-msgid "The following plugins have also been deactivated:"
-msgstr ""
-
-#: admin/plugins.php:618
-msgid "Plugin uninstalled."
-msgstr ""
-
-#: admin/plugins.php:626
-msgid "Plugin network-deactivated."
-msgstr ""
-
-#: admin/plugins.php:652
-#: admin/plugins.php:664
-#: admin/plugins.php:821
-msgid "Update"
-msgstr ""
-
-#: admin/plugins.php:658
-msgid "Activate"
-msgstr ""
-
-#: admin/plugins.php:669
-msgid "%1$s Plugins: %2$s"
-msgstr ""
-
-#: admin/plugins.php:704
-msgid "This plugin might be active on other member sites.  If so, removing the plugin will remove this functionality on those sites."
-msgstr ""
-
-#: admin/plugins.php:705
-msgid "Are you sure you want to continue uninstalling?"
-msgstr ""
-
-#: admin/plugins.php:727
-msgid "No"
-msgstr ""
-
-#: admin/plugins.php:731
-msgid "Yes"
-msgstr ""
-
-#: admin/plugins.php:774
-msgid "Update CBOX"
-msgstr ""
-
-#: admin/plugins.php:834
-#: admin/plugins.php:842
-msgid "Plugin"
-msgstr ""
-
-#: admin/plugins.php:835
-#: admin/plugins.php:843
-msgid "Description"
-msgstr ""
-
-#: admin/plugins.php:867
-msgid "Plugin is already installed"
-msgstr ""
-
-#: admin/plugins.php:870
-msgid "Check this box to install the plugin."
-msgstr ""
-
-#: admin/plugins.php:873
-msgid "Plugin is already active!"
-msgstr ""
-
-#: admin/plugins.php:897
-#: admin/templates/classic/getting-started.php:18
-msgid "Click here to view this plugin's settings page"
-msgstr ""
-
-#: admin/plugins.php:907
-msgid "Click here for documentation on this plugin, from commonsinabox.org"
-msgstr ""
-
-#: admin/plugins.php:909
-msgid "Info"
-msgstr ""
-
-#: admin/plugins.php:917
-msgid "Deactivate this plugin."
-msgstr ""
-
-#: admin/plugins.php:919
-msgid "Deactivate"
-msgstr ""
-
-#: admin/plugins.php:927
-msgid "Uninstall %s"
-msgstr ""
-
-#: admin/plugins.php:929
-msgid "Uninstall"
-msgstr ""
-
-#: admin/plugins.php:939
-msgid "Select the checkbox and click on 'Update' to upgrade this plugin."
-msgstr ""
-
-#: admin/plugins.php:939
-msgid "Update available."
-msgstr ""
-
-#: admin/plugins.php:956
-msgid "Requires: "
-msgstr ""
-
-#: admin/plugins.php:966
-msgid "(enabled)"
-msgstr ""
-
-#: admin/plugins.php:968
-msgid "(disabled)"
-msgstr ""
-
-#: admin/plugins.php:970
-msgid "(automatically installed with %s)"
-msgstr ""
-
-#: admin/plugins.php:988
-msgid "%1$s is network-activated, but we recommend only activating this plugin on the main site."
-msgstr ""
-
-#: admin/plugins.php:992
-msgid "(Change)"
-msgstr ""
-
-#: admin/templates/base/package-details-intro.php:4
-msgid "Welcome to CBOX %1$s! If this is a new WordPress Multisite installation, just click Install to continue. If you are adding CBOX %1$s to an existing installation, please consult the <a href=\"%2$s\">documentation</a> before continuing."
-msgstr ""
-
-#: admin/templates/base/package-details-intro.php:8
-msgid "Welcome to CBOX %1$s! If this is a new WordPress installation, just click Install to continue. If you are adding CBOX %1$s to an existing installation, please consult the <a href=\"%2$s\">documentation</a> before continuing."
-msgstr ""
-
-#: admin/templates/base/package-details-theme.php:2
-msgid "The CBOX %s theme will change how your site looks, and will alter its architecture. Any widgets or menus that you currently have set will need to be reconfigured under the Appearance menu in the Dashboard."
-msgstr ""
-
-#: admin/templates/base/theme-prompt.php:3
-#: admin/templates/base/package-details.php:5
-#: admin/templates/openlab/package-details.php:2
-msgid "Screenshot of theme"
-msgstr ""
-
-#: admin/templates/base/theme-prompt.php:6
-msgid "One last step!"
-msgstr ""
-
-#: admin/templates/base/theme-prompt.php:8
-msgid "The %1$s Theme is the final piece of the Commons In A Box %2$s experience."
-msgstr ""
-
-#: admin/templates/base/plugins-optional-header.php:2
-msgid "The following plugins work well with Commons In A Box %s, but they require a bit of additional setup, so we do not install them by default."
-msgstr ""
-
-#: admin/templates/base/plugins-optional-header.php:3
-#: admin/templates/openlab/plugins-optional-header.php:3
-msgid "To install, check the plugins you want to install and click 'Activate'."
-msgstr ""
-
-#: admin/templates/base/plugins-required-header.php:1
-msgid "To update, check the plugins you want to update and click 'Update'."
-msgstr ""
-
-#: admin/templates/base/plugins-required-header.php:3
-msgid "Required"
-msgstr ""
-
-#: admin/templates/base/plugins-required-header.php:5
-msgid "Commons In A Box %s requires the following plugins."
-msgstr ""
-
-#: admin/templates/base/plugins-install-only-header.php:2
-msgid "The following plugins can improve the WordPress site experience for your users."
-msgstr ""
-
-#: admin/templates/base/plugins-install-only-header.php:3
-msgid "Installing a plugin here makes it available for members in the Plugins area of their site."
-msgstr ""
-
-#: admin/templates/base/plugins-install-only-header.php:4
-msgid "If you would like to add or manage other plugins for your members to access, you can access that area <a href=\"%s\">here</a>."
-msgstr ""
-
-#: admin/templates/base/plugins-install-only-header.php:5
-msgid "To install, check the plugins you want to install and click 'Install'."
-msgstr ""
-
-#: admin/templates/base/welcome.php:6
-#: admin/templates/classic/changelog.php:8
-#: admin/templates/openlab/changelog.php:8
-msgid "Badge"
-msgstr ""
-
-#: admin/templates/base/welcome.php:8
-msgid "Version %s"
-msgstr ""
-
-#: admin/templates/base/package-details.php:8
-#: admin/templates/classic/getting-started.php:37
-#: admin/templates/openlab/package-details.php:4
-msgid "Theme"
-msgstr ""
-
-#: admin/templates/base/plugins-recommended-header.php:1
-msgid "Recommended"
-msgstr ""
-
-#: admin/templates/base/plugins-recommended-header.php:3
-msgid "The following plugins are recommended during initial Commons In A Box %s setup.  We like them, but feel free to deactivate them if you don't need certain functionality."
-msgstr ""
-
-#: admin/templates/base/package-details-plugins.php:2
-msgid "CBOX %s will install and activate plugins that you do not already have installed."
-msgstr ""
-
-#: admin/templates/base/footer.php:4
-msgid "Change packages"
-msgstr ""
-
-#: admin/templates/classic/changelog.php:5
-#: admin/templates/openlab/changelog.php:5
-msgid "Thank you for updating to the latest version!"
-msgstr ""
-
-#: admin/templates/classic/changelog.php:13
-#: admin/templates/openlab/changelog.php:13
-msgid "What&#8217;s New"
-msgstr ""
-
-#: admin/templates/classic/changelog.php:16
-#: admin/templates/classic/welcome-description.php:7
-#: admin/templates/openlab/changelog.php:16
-#: admin/templates/openlab/welcome-description.php:7
-msgid "Credits"
-msgstr ""
-
-#: admin/templates/classic/changelog.php:21
-#: admin/templates/openlab/changelog.php:21
-msgid "Under the Hood"
-msgstr ""
-
-#: admin/templates/classic/changelog.php:27
-msgid "Improved compatibility with BP Customizer settings when using the Nouveau template pack."
-msgstr ""
-
-#: admin/templates/classic/changelog.php:28
-#: admin/templates/openlab/changelog.php:29
-msgid "Improvements to the behavior of network-activated CBOX plugins."
-msgstr ""
-
-#: admin/templates/classic/changelog.php:29
-#: admin/templates/openlab/changelog.php:30
-msgid "Fixed bug in WP-CLI tools that caused theme update to unzip to wrong location in some cases."
-msgstr ""
-
-#: admin/templates/classic/changelog.php:30
-#: admin/templates/openlab/changelog.php:31
-msgid "Improved compatibility with Multi-Network setups."
-msgstr ""
-
-#: admin/templates/classic/changelog.php:37
-#: admin/templates/openlab/changelog.php:38
-msgid "Plugin Updates"
-msgstr ""
-
-#: admin/templates/classic/changelog.php:50
-#: admin/templates/openlab/changelog.php:55
-msgid "Theme Updates"
-msgstr ""
-
-#: admin/templates/classic/changelog.php:54
-msgid "Fixed an issue with making searches on BuddyPress directory pages."
-msgstr ""
-
-#: admin/templates/classic/changelog.php:55
-msgid "Fixed a bug with tab navigation in CBOX Theme options."
-msgstr ""
-
-#: admin/templates/classic/changelog.php:61
-#: admin/templates/openlab/changelog.php:68
-msgid "<a href=\"%s\">Return to the CBOX dashboard &rarr;</a>"
-msgstr ""
-
-#: admin/templates/classic/description.php:2
-msgid "<strong>CBOX Classic is designed for communities of all kinds.</strong> It is used by groups and organizations to create flexible social networks where members can collaborate on projects, publish research, and create repositories of knowledge."
-msgstr ""
-
-#: admin/templates/classic/welcome-description.php:1
-msgid "CBOX Classic is designed for communities of all kinds. It is used by groups and organizations to create flexible social networks where members can collaborate on projects, publish research, and create repositories of knowledge."
-msgstr ""
-
-#: admin/templates/classic/welcome-description.php:3
-msgid "Commons In A Box was made possible by a generous grant from the <a href=\"%1$s\" target=\"_blank\">Alfred P. Sloan Foundation</a> that allowed us to turn the infrastructure that successfully powers the <a href=\"%2$s\" target=\"_blank\">CUNY Academic Commons</a> into a distributable, easy-to-install package."
-msgstr ""
-
-#: admin/templates/classic/welcome-description.php:6
-#: admin/templates/openlab/welcome-description.php:6
-msgid "What's New"
-msgstr ""
-
-#: admin/templates/classic/welcome-description.php:8
-#: admin/templates/openlab/welcome-description.php:8
-msgid "Documentation"
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:3
-msgid "Getting Started with Commons in A Box Classic"
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:12
-msgid "Commons In A Box works by pulling together a number of independent WordPress and BuddyPress plugins. Customize your site by exploring the settings pages for these plugins below."
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:21
-msgid "Click here for plugin documentation at commonsinabox.org"
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:21
-msgid "Info..."
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:30
-msgid "<a href=\"%s\">Manage all your CBOX plugins here</a>"
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:43
-msgid "<a href=\"%1$s\">Install the %2$s theme to get started</a>."
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:52
-msgid "Your current theme is %s."
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:57
-msgid "It looks like this theme is not compatible with BuddyPress."
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:64
-msgid "Did you know that <strong>%s</strong> comes with a cool theme? Check it out below!"
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:66
-msgid "Screenshot of the %s theme"
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:70
-msgid "<a href=\"%1$s\">Like the %2$s theme? Install it!</a>"
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:90
-msgid "You're using a child theme of the <strong>%1$s</strong> theme."
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:92
-msgid "You're using the <strong>%1$s</strong> theme."
-msgstr ""
-
-#: admin/templates/classic/getting-started.php:97
-msgid "<a href=\"%1$s\">Configure the %2$s theme here</a>"
-msgstr ""
-
-#: admin/templates/classic/package-details-plugins.php:2
-msgid "The CBOX Classic package includes several required plugins that provide important features such as groups, user profiles, discussion forums, collaborative document editing, and other functionality. These plugins may interact with any existing plugins you have installed."
-msgstr ""
-
-#: admin/templates/openlab/changelog.php:3
-msgid "Welcome to Commons In A Box OpenLab %s"
-msgstr ""
-
-#: admin/templates/openlab/changelog.php:27
-msgid "Hide \"Group Home\" link from site navs when the group is inaccessible to current user."
-msgstr ""
-
-#: admin/templates/openlab/changelog.php:28
-msgid "Fix bug that could prevent site admins from accessing Dashboard > Plugins in some cases."
-msgstr ""
-
-#: admin/templates/openlab/changelog.php:59
-msgid "Fixed bug with BuddyPress Docs edit mode."
-msgstr ""
-
-#: admin/templates/openlab/changelog.php:60
-msgid "Improved appearance of single page/post content."
-msgstr ""
-
-#: admin/templates/openlab/changelog.php:61
-msgid "Fixed incorrect \"Recent Docs\" and \"Recent Discussions\" subheaders when WordPress is installed in a subdirectory."
-msgstr ""
-
-#: admin/templates/openlab/changelog.php:62
-msgid "Improved language regarding \"Professor(s)\" in group headers."
-msgstr ""
-
-#: admin/templates/openlab/description.php:2
-msgid "<strong>New! CBOX OpenLab is specifically designed for teaching, learning, and collaboration</strong>. It allows faculty members, departments, and entire institutions to create commons spaces for open learning."
-msgstr ""
-
-#: admin/templates/openlab/plugins-optional-header.php:2
-msgid "The following plugins influence the community aspects of your site, but they require a bit of additional setup, so we do not install them by default."
-msgstr ""
-
-#: admin/templates/openlab/welcome-description.php:1
-msgid "Commons In A Box OpenLab is designed for teaching, learning, and collaboration. It allows faculty members, departments, and entire institutions to create commons spaces for open learning."
-msgstr ""
-
-#: admin/templates/openlab/welcome-description.php:3
-msgid "Commons In A Box OpenLab is a collaboration between <a href=\"%1$s\" target=\"_blank\">The Graduate Center, CUNY</a> and <a href=\"%2$s\" target=\"_blank\">New York City College of Technology</a>. It is being created with funding from the National Endowment for the Humanities' <a href=\"%3$s\" target=\"_blank\">Office of Digital Humanities</a>."
-msgstr ""
-
-#: admin/templates/openlab/package-details.php:5
-msgid "The CBOX OpenLab theme will change how your site looks, and will alter its architecture."
-msgstr ""
-
-#: admin/templates/openlab/package-details.php:8
-msgid "The CBOX OpenLab package includes several required plugins that provide important features such as groups, user profiles, discussion forums, collaborative document editing, and other functionality. These plugins may interact with any existing plugins you have installed."
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:4
-msgid "Getting Started with Commons in A Box OpenLab"
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:8
-msgid "We've assembled some links to get you started. Check out our <a href=\"%1$s\" target=\"_blank\">documentation</a> for detailed instructions. Questions? Post them on our <a href=\"%2$s\" target=\"_blank\">CBOX OpenLab Support Forum</a>."
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:13
-msgid "Manage Community Feature plugins for your site and Member Site Plugins that you would like to make available to your members for their individual WordPress sites."
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:16
-msgid "Member Settings"
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:17
-msgid "Modify member categories, their capabilities and permissions, who can create an account, and what types of accounts different members can create. These settings also include email domain whitelisting and registration codes to restrict access by account type."
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:20
-msgid "Group Settings"
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:21
-msgid "Affect the appearance and functionality of groups across your site. You can change the features and site templates available to groups, as well as create and assign categories for groups that can be used to filter items on the group directory pages."
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:24
-msgid "Academic Units"
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:25
-msgid "Create unit-types that best describe how your institution is organized &ndash; for example, Departments that are located within Divisions &ndash; and define the units within each type. These units can be utilized as filters across your site's groups and for members to associate themselves in their profiles."
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:28
-msgid "Brand Settings"
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:29
-msgid "Customize your site including color scheme, logo, homepage layout, footer content, and widgets."
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:32
-msgid "Communication Settings"
-msgstr ""
-
-#: admin/templates/openlab/getting-started.php:33
-msgid "Manage email and other communication settings, including email template content and appearance and group email subscription settings."
-msgstr ""
-
-#: admin/theme-install.php:205
-msgid "Continue to CBOX Dashboard &rarr;"
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:592
+msgid "Incorrect plugin version installed"
 msgstr ""
 
 #: lib/wp-plugin-dependencies/plugin-dependencies.php:595
 msgid "%s (Version %s required)"
+msgstr ""
+
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:606
+msgid "WordPress version %s required"
+msgstr ""
+
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:607
+msgid "(Upgrade now!)"
+msgstr ""
+
+#: lib/wp-plugin-dependencies/plugin-dependencies.php:664
+msgid "\"%s\" cannot be activated. Before you can activate this plugin, please <a href=\"%s\">address the issues listed here</a>."
+msgstr ""
+
+#. Plugin Name of the plugin
+msgid "CBOX-OpenLab Core"
+msgstr ""
+
+#. Description of the plugin
+msgid "Core functionality for CBOX-OpenLab"
+msgstr ""
+
+#: classes/AcademicUnitType.php:376
+msgctxt "Academic Unit Type plural label"
+msgid "Plural"
+msgstr ""
+
+#: classes/AcademicUnitType.php:377
+#: classes/GroupType.php:474
+#: classes/MemberType.php:190
+msgid "Used in directory titles."
+msgstr ""
+
+#: classes/AcademicUnitType.php:382
+msgctxt "Academic Unit Type singular label"
+msgid "Singular"
+msgstr ""
+
+#: classes/AcademicUnitType.php:383
+msgid "Used on group and member profiles."
+msgstr ""
+
+#: classes/API/AcademicUnits.php:68
+msgid "No academic unit found"
+msgstr ""
+
+#: classes/API/AcademicUnits.php:102
+#: classes/API/AcademicUnitTypes.php:85
+#: classes/API/ItemTypes.php:117
+msgid "OK"
+msgstr ""
+
+#: classes/API/AcademicUnits.php:105
+msgid "Cannot delete academic unit."
+msgstr ""
+
+#: classes/API/AcademicUnitTypes.php:71
+msgid "No academic unit type found"
+msgstr ""
+
+#: classes/API/AcademicUnitTypes.php:88
+msgid "Cannot delete type."
+msgstr ""
+
+#: classes/API/GroupCategories.php:69
+msgid "No term found by that ID."
+msgstr ""
+
+#: classes/API/ItemTypes.php:106
+msgid "No item type found by that ID."
+msgstr ""
+
+#: classes/API/ItemTypes.php:113
+msgid "Type cannot be deleted"
+msgstr ""
+
+#: classes/API/SignupCodes.php:51
+msgid "Could not create signup code."
+msgstr ""
+
+#: classes/GroupType.php:311
+msgctxt "Group Type label"
+msgid "Course Code"
+msgstr ""
+
+#: classes/GroupType.php:312
+msgid "The label for the \"Course Code\" input when editing Course settings."
+msgstr ""
+
+#: classes/GroupType.php:317
+#: classes/Install.php:227
+msgid "Course Information"
+msgstr ""
+
+#: classes/GroupType.php:318
+msgid "The label for the course settings section containing Course Code and other catalog data."
+msgstr ""
+
+#: classes/GroupType.php:323
+msgid "Course Information Help Text"
+msgstr ""
+
+#: classes/GroupType.php:324
+msgid "The helper text in the Course Information admin section of a Course."
+msgstr ""
+
+#: classes/GroupType.php:329
+msgid "Create Item"
+msgstr ""
+
+#: classes/GroupType.php:330
+msgid "The text used for \"Create\" links."
+msgstr ""
+
+#: classes/GroupType.php:335
+msgid "Create/Clone Item"
+msgstr ""
+
+#: classes/GroupType.php:336
+msgid "The text used for \"Create/Clone\" links."
+msgstr ""
+
+#: classes/GroupType.php:341
+msgid "Item Creation"
+msgstr ""
+
+#: classes/GroupType.php:342
+msgid "The label used for the first step of the creation/edit process."
+msgstr ""
+
+#: classes/GroupType.php:347
+msgid "Creation Explanatory Text"
+msgstr ""
+
+#: classes/GroupType.php:348
+msgid "Displayed near the top of the creation screen."
+msgstr ""
+
+#: classes/GroupType.php:353
+msgid "Clone Help Text"
+msgstr ""
+
+#: classes/GroupType.php:354
+msgid "Used to clarify the cloning process during creation."
+msgstr ""
+
+#: classes/GroupType.php:359
+msgid "Name Help Text"
+msgstr ""
+
+#: classes/GroupType.php:360
+msgid "Used to clarify the \"Name\" field when creating or editing an item."
+msgstr ""
+
+#: classes/GroupType.php:365
+msgid "Avatar Help Text"
+msgstr ""
+
+#: classes/GroupType.php:366
+msgid "Used to clarify the \"Upload Avatar\" field when creating or editing an item."
+msgstr ""
+
+#: classes/GroupType.php:371
+msgid "Avatar Help Text - \"Can't Decide\""
+msgstr ""
+
+#: classes/GroupType.php:372
+msgid "Used below the avatar selection panel when creating or editing an item."
+msgstr ""
+
+#: classes/GroupType.php:377
+msgid "URL Help Text"
+msgstr ""
+
+#: classes/GroupType.php:378
+msgid "Used to clarify the \"URL\" field when creating or editing an item."
+msgstr ""
+
+#: classes/GroupType.php:383
+msgid "Privacy Help Text"
+msgstr ""
+
+#: classes/GroupType.php:384
+msgid "Describes group privacy settings when creating or editing a group."
+msgstr ""
+
+#: classes/GroupType.php:389
+msgid "Privacy Help Text - New Group"
+msgstr ""
+
+#: classes/GroupType.php:390
+msgid "Provides additional context for privacy settings when creating a new group."
+msgstr ""
+
+#: classes/GroupType.php:395
+msgid "Privacy Help Text - Public Content"
+msgstr ""
+
+#: classes/GroupType.php:396
+msgid "Describes what \"Public\" means for content visibility during group creation or editing."
+msgstr ""
+
+#: classes/GroupType.php:401
+msgid "Privacy Help Text - Public Directory"
+msgstr ""
+
+#: classes/GroupType.php:402
+msgid "Describes what \"Public\" means for visibility in directories during group creation or editing."
+msgstr ""
+
+#: classes/GroupType.php:407
+msgid "Privacy Help Text - Public Membership"
+msgstr ""
+
+#: classes/GroupType.php:408
+msgid "Describes how \"Public\" affects community members' ability to join the group during group creation or editing."
+msgstr ""
+
+#: classes/GroupType.php:413
+msgid "Privacy Help Text - Private Content"
+msgstr ""
+
+#: classes/GroupType.php:414
+msgid "Describes group content that is limited to group members."
+msgstr ""
+
+#: classes/GroupType.php:419
+msgid "Privacy Help Text - Membership By Request"
+msgstr ""
+
+#: classes/GroupType.php:420
+msgid "Describes membership requirements for groups that allow for membership requests."
+msgstr ""
+
+#: classes/GroupType.php:425
+msgid "Privacy Help Text - Private Directory"
+msgstr ""
+
+#: classes/GroupType.php:426
+msgid "Describes groups that are hidden from directories and search results."
+msgstr ""
+
+#: classes/GroupType.php:431
+msgid "Privacy Help Text - Membership By Invitation"
+msgstr ""
+
+#: classes/GroupType.php:432
+msgid "Describes membership requirements for groups can only be joined by invitation."
+msgstr ""
+
+#: classes/GroupType.php:437
+msgid "Group Home"
+msgstr ""
+
+#: classes/GroupType.php:438
+msgid "Used to create a Home link in a group's nav menus."
+msgstr ""
+
+#: classes/GroupType.php:443
+msgid "Group Site"
+msgstr ""
+
+#: classes/GroupType.php:444
+msgid "Used in group directories and elsewhere to create links to the group's site."
+msgstr ""
+
+#: classes/GroupType.php:449
+msgid "Group Betails"
+msgstr ""
+
+#: classes/GroupType.php:450
+msgid "Used in group admin navigation."
+msgstr ""
+
+#: classes/GroupType.php:455
+msgctxt "Group Type label"
+msgid "My Groups"
+msgstr ""
+
+#: classes/GroupType.php:456
+#: classes/GroupType.php:462
+msgid "Used in personal navigation and on member profiles."
+msgstr ""
+
+#: classes/GroupType.php:461
+msgctxt "Group Type label"
+msgid "My Portfolio"
+msgstr ""
+
+#: classes/GroupType.php:467
+msgctxt "Group Type label"
+msgid "My Portfolio Site"
+msgstr ""
+
+#: classes/GroupType.php:468
+msgid "Used as the link to a user's own portfolio site."
+msgstr ""
+
+#: classes/GroupType.php:473
+#: classes/MemberType.php:189
+msgctxt "Member Type plural label"
+msgid "Plural"
+msgstr ""
+
+#: classes/GroupType.php:479
+msgctxt "Group Type label"
+msgid "Section Code"
+msgstr ""
+
+#: classes/GroupType.php:480
+msgid "The label for the \"Section Code\" input when editing Course settings."
+msgstr ""
+
+#: classes/GroupType.php:485
+#: classes/MemberType.php:183
+msgctxt "Member Type singular label"
+msgid "Singular"
+msgstr ""
+
+#: classes/GroupType.php:486
+#: classes/MemberType.php:184
+msgid "Used wherever a specific member's Type is mentioned, such as the User Edit interface."
+msgstr ""
+
+#: classes/GroupType.php:491
+msgctxt "Group Type label"
+msgid "Status: Open"
+msgstr ""
+
+#: classes/GroupType.php:492
+msgid "Used to describe a group that is open and either has no site or has a site that is also open."
+msgstr ""
+
+#: classes/GroupType.php:497
+msgctxt "Group Type label"
+msgid "Status: Open, Community Site"
+msgstr ""
+
+#: classes/GroupType.php:498
+msgid "Used to describe a group that is open and has a site that is visible only to community members."
+msgstr ""
+
+#: classes/GroupType.php:503
+msgctxt "Group Type label"
+msgid "Status: Open, Private Site"
+msgstr ""
+
+#: classes/GroupType.php:504
+msgid "Used to describe a group that is open and has a site that is private."
+msgstr ""
+
+#: classes/GroupType.php:509
+msgctxt "Group Type label"
+msgid "Status: Private"
+msgstr ""
+
+#: classes/GroupType.php:510
+msgid "Used to describe a group that is private and has no site."
+msgstr ""
+
+#: classes/GroupType.php:515
+msgctxt "Group Type label"
+msgid "Status: Private, Community Site"
+msgstr ""
+
+#: classes/GroupType.php:516
+msgid "Used to describe a group that is private and has a site that is visible only to community members."
+msgstr ""
+
+#: classes/GroupType.php:521
+msgctxt "Group Type label"
+msgid "Status: Private, Open Site"
+msgstr ""
+
+#: classes/GroupType.php:522
+msgid "Used to describe a group that is private and has an open site."
+msgstr ""
+
+#: classes/GroupType.php:527
+msgctxt "Group Type label"
+msgid "Status: Private, Private Site"
+msgstr ""
+
+#: classes/GroupType.php:528
+msgid "Used to describe a group that is private and has a site that is private."
+msgstr ""
+
+#: classes/GroupType.php:533
+msgid "Visit Group Site"
+msgstr ""
+
+#: classes/GroupType.php:534
+msgid "Used in group navigation and elsewhere to create links to the group's site."
+msgstr ""
+
+#: classes/GroupType.php:539
+msgid "Site Help Text"
+msgstr ""
+
+#: classes/GroupType.php:540
+msgid "Help text displayed at the top of the Associated Site section of group edit/creation."
+msgstr ""
+
+#: classes/GroupType.php:545
+msgid "Site Address Help Text"
+msgstr ""
+
+#: classes/GroupType.php:546
+msgid "Text describing the choice of URL when creating a group site."
+msgstr ""
+
+#: classes/GroupType.php:551
+msgid "Site Feed Check Help Text"
+msgstr ""
+
+#: classes/GroupType.php:552
+msgid "Text describing the \"Check\" button for external feeds when creating a group site."
+msgstr ""
+
+#: classes/GroupType.php:557
+msgctxt "Group Type label"
+msgid "Visit Portfolio Site"
+msgstr ""
+
+#: classes/GroupType.php:558
+msgid "Used as the link to another user's portfolio site."
+msgstr ""
+
+#: classes/GroupType.php:563
+msgid "Settings Help Text - Discussion"
+msgstr ""
+
+#: classes/GroupType.php:564
+msgid "Help text for the Discussion Settings panel."
+msgstr ""
+
+#: classes/GroupType.php:569
+msgid "Settings Help Text - Calendar"
+msgstr ""
+
+#: classes/GroupType.php:570
+msgid "Help text for the Calendar Settings panel."
+msgstr ""
+
+#: classes/GroupType.php:575
+msgid "Settings Help Text - Calendar, Members Only"
+msgstr ""
+
+#: classes/GroupType.php:576
+msgid "Help text for the \"Members Only\" option on the Calendar Settings panel."
+msgstr ""
+
+#: classes/GroupType.php:581
+msgid "Settings Help Text - Calendar, Admins Only"
+msgstr ""
+
+#: classes/GroupType.php:582
+msgid "Help text for the \"Admins and Mods Only\" option on the Calendar Settings panel."
+msgstr ""
+
+#: classes/GroupType.php:587
+msgid "Settings Help Text - Related Links"
+msgstr ""
+
+#: classes/GroupType.php:588
+msgid "Help text for the Related Links List Settings panel."
+msgstr ""
+
+#: classes/GroupType.php:593
+msgid "Settings Help Text - Portfolio List"
+msgstr ""
+
+#: classes/GroupType.php:594
+msgid "Help text for the Portfolio List Settings panel."
+msgstr ""
+
+#: classes/GroupType.php:599
+msgid "Invite Members To Group"
+msgstr ""
+
+#: classes/GroupType.php:600
+msgid "Used in group invitation navigation."
+msgstr ""
+
+#: classes/GroupType.php:605
+msgid "Invite Community Members To Group"
+msgstr ""
+
+#: classes/GroupType.php:606
+msgid "Used as a header on group creation/settings panel."
+msgstr ""
+
+#: classes/GroupType.php:611
+msgid "Search for Community Members to Invite to Group"
+msgstr ""
+
+#: classes/GroupType.php:612
+msgid "Used as help text when inviting community members to a group."
+msgstr ""
+
+#: classes/GroupType.php:617
+msgid "Group Contact"
+msgstr ""
+
+#: classes/GroupType.php:618
+msgid "The label for the Group Contact feature."
+msgstr ""
+
+#: classes/GroupType.php:623
+msgid "Group Contact Help Text"
+msgstr ""
+
+#: classes/GroupType.php:624
+msgid "Help text for the Group Contact feature."
+msgstr ""
+
+#: classes/GroupType.php:629
+msgid "Group Discussion"
+msgstr ""
+
+#: classes/GroupType.php:630
+msgid "Used for forum navigation."
+msgstr ""
+
+#: classes/GroupType.php:661
+msgid "Site Template - %s"
+msgstr ""
+
+#: classes/GroupType.php:678
+msgid "Welcome! This is your first post. Edit or delete it, then start blogging!"
+msgstr ""
+
+#: classes/GroupType.php:708
+#: classes/Install.php:929
+#: functions.php:24
+#: functions.php:129
+#: lib/menus.php:11
+msgid "Main Menu"
+msgstr ""
+
+#: classes/GroupType.php:715
+msgid "sample-page"
+msgstr ""
+
+#: classes/Install.php:72
+#: classes/Install.php:75
+msgid "Students"
+msgstr ""
+
+#: classes/Install.php:74
+#: classes/Install.php:588
+msgid "Student"
+msgstr ""
+
+#: classes/Install.php:83
+#: classes/Install.php:85
+#: classes/Install.php:86
+#: classes/Install.php:252
+#: classes/Install.php:572
+msgid "Faculty"
+msgstr ""
+
+#: classes/Install.php:94
+#: classes/Install.php:96
+#: classes/Install.php:97
+#: classes/Install.php:584
+msgid "Staff"
+msgstr ""
+
+#: classes/Install.php:105
+#: classes/Install.php:107
+#: classes/Install.php:108
+msgid "Alumni"
+msgstr ""
+
+#: classes/Install.php:179
+#: classes/Install.php:206
+msgid "Courses"
+msgstr ""
+
+#: classes/Install.php:186
+msgid "Syllabus"
+msgstr ""
+
+#: classes/Install.php:187
+msgid "This is a default syllabus page. Enter your syllabus here, or delete this page if you don't wish to use it."
+msgstr ""
+
+#: classes/Install.php:191
+msgid "Assignments"
+msgstr ""
+
+#: classes/Install.php:192
+msgid "This is a default assignments page. Enter your assignments here, or delete this page if you don't wish to use it."
+msgstr ""
+
+#: classes/Install.php:196
+msgid "Sample Assignment"
+msgstr ""
+
+#: classes/Install.php:205
+msgid "Course"
+msgstr ""
+
+#: classes/Install.php:207
+msgid "Create/Clone Course"
+msgstr ""
+
+#: classes/Install.php:208
+msgid "Course Creation"
+msgstr ""
+
+#: classes/Install.php:209
+msgid "Set up the name, URL, avatar, and other settings and permissions for your course. These settings affect the course home, discussion, docs, and files."
+msgstr ""
+
+#: classes/Install.php:210
+msgid "Note: Cloning copies the course home, site set-up, and all documents, files, discussions and posts you've created. Posts will be set to \"draft\" mode. The clone will not copy membership or member-created documents, files, discussions, comments or posts."
+msgstr ""
+
+#: classes/Install.php:211
+msgid "Please choose your course name carefully. A clear name will make it easier for others to find your course. We recommend keeping the name under 50 characters."
+msgstr ""
+
+#: classes/Install.php:212
+msgid "Upload an image to use as an avatar for this course. The image will be shown on the course home page, and in search results."
+msgstr ""
+
+#: classes/Install.php:213
+msgid "Can't decide? You can upload a photo once the course is created."
+msgstr ""
+
+#: classes/Install.php:214
+msgid "Choose a unique URL that will be the home for your course."
+msgstr ""
+
+#: classes/Install.php:215
+msgid "These settings affect how others view your course."
+msgstr ""
+
+#: classes/Install.php:216
+msgid "You may change these settings later in the course settings."
+msgstr ""
+
+#: classes/Install.php:217
+msgid "Course and related content and activity will be visible to the public."
+msgstr ""
+
+#: classes/Install.php:218
+msgid "Course will be listed in the \"Courses\" directory, in search results, and may be displayed on the community home page."
+msgstr ""
+
+#: classes/Install.php:219
+msgid "Any community member may join this course."
+msgstr ""
+
+#: classes/Install.php:220
+msgid "Course content and activity will only be visible to members of the course."
+msgstr ""
+
+#: classes/Install.php:221
+msgid "Only community members who request membership and are accepted may join this course."
+msgstr ""
+
+#: classes/Install.php:222
+msgid "Course will NOT be listed in the \"Courses\" directory, in search results, or on the community home page."
+msgstr ""
+
+#: classes/Install.php:223
+msgid "Only community members who are invited may join this course."
+msgstr ""
+
+#: classes/Install.php:224
+msgid "Course Details"
+msgstr ""
+
+#: classes/Install.php:225
+msgid "My Courses"
+msgstr ""
+
+#: classes/Install.php:226
+msgid "Course Code"
+msgstr ""
+
+#: classes/Install.php:228
+msgid "The following fields are not required, but including this information will make it easier for others to find your Course."
+msgstr ""
+
+#: classes/Install.php:229
+msgid "Section Code"
+msgstr ""
+
+#: classes/Install.php:230
+msgid "Course Site"
+msgstr ""
+
+#: classes/Install.php:231
+msgid "This Course is OPEN."
+msgstr ""
+
+#: classes/Install.php:232
+msgid "This Course is OPEN, but only logged-in community members may view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:233
+msgid "This Course is OPEN, but the corresponding Site is PRIVATE."
+msgstr ""
+
+#: classes/Install.php:234
+msgid "This Course is PRIVATE."
+msgstr ""
+
+#: classes/Install.php:235
+msgid "This Course is PRIVATE, but all logged-in community members may view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:236
+msgid "This Course is PRIVATE, but the corresponding Site is OPEN to all visitors."
+msgstr ""
+
+#: classes/Install.php:237
+msgid "This Course is PRIVATE, and you must be a member to view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:238
+msgid "Each course can also have an optional associated site. This is a WordPress site that all members of your course can access and contribute to."
+msgstr ""
+
+#: classes/Install.php:239
+msgid "Take a moment to consider an address for the site associated with your course. You will not be able to change it once you've created it."
+msgstr ""
+
+#: classes/Install.php:240
+msgid "Note: Please click the Check button to search for Post and Comment feeds for your external site. Doing so will push new activity to the course page. If no feeds are detected, you may type in the Post and Comment feed URLs directly or just leave blank."
+msgstr ""
+
+#: classes/Install.php:241
+msgid "Visit Course Site"
+msgstr ""
+
+#: classes/Install.php:242
+msgid "Course Home"
+msgstr ""
+
+#: classes/Install.php:243
+msgid "These settings enable or disable the discussion forum on your course home page."
+msgstr ""
+
+#: classes/Install.php:244
+msgid "These settings determine who can create an event for your course calendar and for the community-wide calendar."
+msgstr ""
+
+#: classes/Install.php:245
+msgid "Any course member may connect events to this course."
+msgstr ""
+
+#: classes/Install.php:246
+msgid "Only administrators and moderators may connect events to this course."
+msgstr ""
+
+#: classes/Install.php:247
+msgid "These settings enable or disable the related links list display on your course home page."
+msgstr ""
+
+#: classes/Install.php:248
+msgid "These settings enable or disable the member portfolio list display on your course home page."
+msgstr ""
+
+#: classes/Install.php:249
+msgid "Invite Members to Course"
+msgstr ""
+
+#: classes/Install.php:250
+msgid "Invite Community Members to Course"
+msgstr ""
+
+#: classes/Install.php:251
+msgid "Search for Community Members to invite to your course"
+msgstr ""
+
+#: classes/Install.php:253
+msgid "By default, you are the sole faculty member associated with this Course. You may add or remove faculty once your Course has more members."
+msgstr ""
+
+#: classes/Install.php:254
+msgid "Course Discussion"
+msgstr ""
+
+#: classes/Install.php:271
+#: classes/Install.php:280
+msgid "Projects"
+msgstr ""
+
+#: classes/Install.php:279
+msgid "Project"
+msgstr ""
+
+#: classes/Install.php:281
+msgid "Create Project"
+msgstr ""
+
+#: classes/Install.php:282
+msgid "Project Creation"
+msgstr ""
+
+#: classes/Install.php:283
+msgid "Set up the name, URL, avatar, and other settings and permissions for your project. These settings affect the project home, discussion, docs, and files."
+msgstr ""
+
+#: classes/Install.php:284
+msgid "Please choose your project name carefully. A clear name will make it easier for others to find your project. We recommend keeping the name under 50 characters."
+msgstr ""
+
+#: classes/Install.php:285
+msgid "Upload an image to use as an avatar for this project. The image will be shown on the project home page, and in search results."
+msgstr ""
+
+#: classes/Install.php:286
+msgid "Can't decide? You can upload a photo once the project is created."
+msgstr ""
+
+#: classes/Install.php:287
+msgid "Choose a unique URL that will be the home for your project."
+msgstr ""
+
+#: classes/Install.php:288
+msgid "These settings affect how others view your project."
+msgstr ""
+
+#: classes/Install.php:289
+msgid "You may change these settings later in the project settings."
+msgstr ""
+
+#: classes/Install.php:290
+msgid "Project and related content and activity will be visible to the public."
+msgstr ""
+
+#: classes/Install.php:291
+msgid "Project will be listed in the \"Projects\" directory, in search results, and may be displayed on the community home page."
+msgstr ""
+
+#: classes/Install.php:292
+msgid "Any community member may join this project."
+msgstr ""
+
+#: classes/Install.php:293
+msgid "Project content and activity will only be visible to members of the project."
+msgstr ""
+
+#: classes/Install.php:294
+msgid "Only community members who request membership and are accepted may join this project."
+msgstr ""
+
+#: classes/Install.php:295
+msgid "Project will NOT be listed in the \"Projects\" directory, in search results, or on the community home page."
+msgstr ""
+
+#: classes/Install.php:296
+msgid "Only community members who are invited may join this project."
+msgstr ""
+
+#: classes/Install.php:297
+msgid "Project Details"
+msgstr ""
+
+#: classes/Install.php:298
+msgid "My Projects"
+msgstr ""
+
+#: classes/Install.php:299
+msgid "Project Site"
+msgstr ""
+
+#: classes/Install.php:300
+msgid "This Project is OPEN."
+msgstr ""
+
+#: classes/Install.php:301
+msgid "This Project is OPEN, but only logged-in community members may view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:302
+msgid "This Project is OPEN, but the corresponding Site is PRIVATE."
+msgstr ""
+
+#: classes/Install.php:303
+msgid "This Project is PRIVATE."
+msgstr ""
+
+#: classes/Install.php:304
+msgid "This Project is PRIVATE, but all logged-in community members may view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:305
+msgid "This Project is PRIVATE, but the corresponding Site is OPEN to all visitors."
+msgstr ""
+
+#: classes/Install.php:306
+msgid "This Project is PRIVATE, and you must be a member to view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:307
+msgid "Each project can also have an optional associated site. This is a WordPress site that all members of your project can access and contribute to."
+msgstr ""
+
+#: classes/Install.php:308
+msgid "Take a moment to consider an address for the site associated with your project. You will not be able to change it once you've created it."
+msgstr ""
+
+#: classes/Install.php:309
+msgid "Note: Please click the Check button to search for Post and Comment feeds for your external site. Doing so will push new activity to the project page. If no feeds are detected, you may type in the Post and Comment feed URLs directly or just leave blank."
+msgstr ""
+
+#: classes/Install.php:310
+msgid "Visit Project Site"
+msgstr ""
+
+#: classes/Install.php:311
+msgid "Project Home"
+msgstr ""
+
+#: classes/Install.php:312
+msgid "These settings enable or disable the discussion forum on your project home page."
+msgstr ""
+
+#: classes/Install.php:313
+msgid "These settings determine who can create an event for your project calendar and for the community-wide calendar."
+msgstr ""
+
+#: classes/Install.php:314
+msgid "Any project member may connect events to this project."
+msgstr ""
+
+#: classes/Install.php:315
+msgid "Only administrators and moderators may connect events to this project."
+msgstr ""
+
+#: classes/Install.php:316
+msgid "These settings enable or disable the related links list display on your project home page."
+msgstr ""
+
+#: classes/Install.php:317
+msgid "These settings enable or disable the member portfolio list display on your project home page."
+msgstr ""
+
+#: classes/Install.php:318
+msgid "Invite Members to Project"
+msgstr ""
+
+#: classes/Install.php:319
+msgid "Invite Community Members to Project"
+msgstr ""
+
+#: classes/Install.php:320
+msgid "Search for Community Members to invite to your project"
+msgstr ""
+
+#: classes/Install.php:321
+msgid "Project Contact"
+msgstr ""
+
+#: classes/Install.php:322
+msgid "By default, you are the Project Contact. You may add or remove Project Contacts once your portfolio has more members."
+msgstr ""
+
+#: classes/Install.php:323
+msgid "Project Discussion"
+msgstr ""
+
+#: classes/Install.php:340
+#: classes/Install.php:349
+msgid "Clubs"
+msgstr ""
+
+#: classes/Install.php:348
+msgid "Club"
+msgstr ""
+
+#: classes/Install.php:350
+msgid "Create Club"
+msgstr ""
+
+#: classes/Install.php:351
+msgid "Club Creation"
+msgstr ""
+
+#: classes/Install.php:352
+msgid "Set up the name, URL, avatar, and other settings and permissions for your club. These settings affect the club home, discussion, docs, and files."
+msgstr ""
+
+#: classes/Install.php:353
+msgid "Please choose your club name carefully. A clear name will make it easier for others to find your club. We recommend keeping the name under 50 characters."
+msgstr ""
+
+#: classes/Install.php:354
+msgid "Upload an image to use as an avatar for this club. The image will be shown on the club home page, and in search results."
+msgstr ""
+
+#: classes/Install.php:355
+msgid "Can't decide? You can upload a photo once the club is created."
+msgstr ""
+
+#: classes/Install.php:356
+msgid "Choose a unique URL that will be the home for your club."
+msgstr ""
+
+#: classes/Install.php:357
+msgid "These settings affect how others view your club."
+msgstr ""
+
+#: classes/Install.php:358
+msgid "You may change these settings later in the club settings."
+msgstr ""
+
+#: classes/Install.php:359
+msgid "Club and related content and activity will be visible to the public."
+msgstr ""
+
+#: classes/Install.php:360
+msgid "Club will be listed in the \"Clubs\" directory, in search results, and may be displayed on the community home page."
+msgstr ""
+
+#: classes/Install.php:361
+msgid "Any community member may join this club."
+msgstr ""
+
+#: classes/Install.php:362
+msgid "Club content and activity will only be visible to members of the club."
+msgstr ""
+
+#: classes/Install.php:363
+msgid "Only community members who request membership and are accepted may join this club."
+msgstr ""
+
+#: classes/Install.php:364
+msgid "Club will NOT be listed in the \"Clubs\" directory, in search results, or on the community home page."
+msgstr ""
+
+#: classes/Install.php:365
+msgid "Only community members who are invited may join this club."
+msgstr ""
+
+#: classes/Install.php:366
+msgid "Club Details"
+msgstr ""
+
+#: classes/Install.php:367
+msgid "My Clubs"
+msgstr ""
+
+#: classes/Install.php:368
+msgid "Club Site"
+msgstr ""
+
+#: classes/Install.php:369
+msgid "This Club is OPEN."
+msgstr ""
+
+#: classes/Install.php:370
+msgid "This Club is OPEN, but only logged-in community members may view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:371
+msgid "This Club is OPEN, but the corresponding Site is PRIVATE."
+msgstr ""
+
+#: classes/Install.php:372
+msgid "This Club is PRIVATE."
+msgstr ""
+
+#: classes/Install.php:373
+msgid "This Club is PRIVATE, but all logged-in community members may view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:374
+msgid "This Club is PRIVATE, but the corresponding Site is OPEN to all visitors."
+msgstr ""
+
+#: classes/Install.php:375
+msgid "This Club is PRIVATE, and you must be a member to view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:376
+msgid "Each club can also have an optional associated site. This is a WordPress site that all members of your club can access and contribute to."
+msgstr ""
+
+#: classes/Install.php:377
+msgid "Take a moment to consider an address for the site associated with your club. You will not be able to change it once you've created it."
+msgstr ""
+
+#: classes/Install.php:378
+msgid "Note: Please click the Check button to search for Post and Comment feeds for your external site. Doing so will push new activity to the club page. If no feeds are detected, you may type in the Post and Comment feed URLs directly or just leave blank."
+msgstr ""
+
+#: classes/Install.php:379
+msgid "Visit Club Site"
+msgstr ""
+
+#: classes/Install.php:380
+msgid "Club Home"
+msgstr ""
+
+#: classes/Install.php:381
+msgid "These settings enable or disable the discussion forum on your club home page."
+msgstr ""
+
+#: classes/Install.php:382
+msgid "These settings determine who can create an event for your club calendar and for the community-wide calendar."
+msgstr ""
+
+#: classes/Install.php:383
+msgid "Any club member may connect events to this club."
+msgstr ""
+
+#: classes/Install.php:384
+msgid "Only administrators and moderators may connect events to this club."
+msgstr ""
+
+#: classes/Install.php:385
+msgid "These settings enable or disable the related links list display on your club home page."
+msgstr ""
+
+#: classes/Install.php:386
+msgid "These settings enable or disable the member portfolio list display on your club home page."
+msgstr ""
+
+#: classes/Install.php:387
+msgid "Invite Members to Club"
+msgstr ""
+
+#: classes/Install.php:388
+msgid "Invite Community Members to Club"
+msgstr ""
+
+#: classes/Install.php:389
+msgid "Search for Community Members to invite to your club"
+msgstr ""
+
+#: classes/Install.php:390
+msgid "Club Contact"
+msgstr ""
+
+#: classes/Install.php:391
+msgid "By default, you are the Club Contact. You may add or remove Club Contacts once your portfolio has more members."
+msgstr ""
+
+#: classes/Install.php:392
+msgid "Club Discussion"
+msgstr ""
+
+#: classes/Install.php:414
+#: classes/Install.php:452
+msgid "Portfolios"
+msgstr ""
+
+#: classes/Install.php:421
+msgid "About Me"
+msgstr ""
+
+#: classes/Install.php:422
+msgid "This is a good place to introduce yourself and explain what visitors will find on this site."
+msgstr ""
+
+#: classes/Install.php:426
+msgid "Academics"
+msgstr ""
+
+#: classes/Install.php:427
+msgid "On this page, give an overview of your academic goals. Then edit the sub-section page Sample Course or create additional sub-section pages with a selection of your best academic work."
+msgstr ""
+
+#: classes/Install.php:431
+msgid "Sample Course"
+msgstr ""
+
+#: classes/Install.php:437
+msgid "Career"
+msgstr ""
+
+#: classes/Install.php:438
+msgid "This is a good place to describe your professional goals and give an overview of your career experience. Then edit the sub-section page Resume or create additional sub-section pages to develop the career section of your portfolio."
+msgstr ""
+
+#: classes/Install.php:442
+msgid "Resume"
+msgstr ""
+
+#: classes/Install.php:453
+#: classes/Install.php:469
+msgid "Create Portfolio"
+msgstr ""
+
+#: classes/Install.php:454
+msgid "Portfolio Creation"
+msgstr ""
+
+#: classes/Install.php:455
+msgid "Set up the name, URL, avatar, and other settings and permissions for your portfolio. These settings affect the portfolio home, discussion, docs, and files."
+msgstr ""
+
+#: classes/Install.php:456
+msgid "The suggested Portfolio Name below uses your first and last name. If you do not wish to use your full name, you may change it now or at any time in the future."
+msgstr ""
+
+#: classes/Install.php:457
+msgid "Upload an image to use as an avatar for this portfolio. The image will be shown on the portfolio home page, and in search results."
+msgstr ""
+
+#: classes/Install.php:458
+msgid "Can't decide? You can upload a photo once the portfolio is created."
+msgstr ""
+
+#: classes/Install.php:459
+msgid "Choose a unique URL that will be the home for your portfolio."
+msgstr ""
+
+#: classes/Install.php:460
+msgid "These settings affect how others view your portfolio."
+msgstr ""
+
+#: classes/Install.php:461
+msgid "You may change these settings later in the portfolio settings."
+msgstr ""
+
+#: classes/Install.php:462
+msgid "Portfolio and related content and activity will be visible to the public."
+msgstr ""
+
+#: classes/Install.php:463
+msgid "Portfolio will be listed in the \"Portfolios\" directory, in search results, and may be displayed on the community home page."
+msgstr ""
+
+#: classes/Install.php:464
+msgid "Any community member may join this portfolio."
+msgstr ""
+
+#: classes/Install.php:465
+msgid "Portfolio content and activity will only be visible to members of the portfolio."
+msgstr ""
+
+#: classes/Install.php:466
+msgid "Only community members who request membership and are accepted may join this portfolio."
+msgstr ""
+
+#: classes/Install.php:467
+msgid "Portfolio will NOT be listed in the \"Portfolios\" directory, in search results, or on the community home page."
+msgstr ""
+
+#: classes/Install.php:468
+msgid "Only community members who are invited may join this portfolio."
+msgstr ""
+
+#: classes/Install.php:470
+msgid "Portfolio Details"
+msgstr ""
+
+#: classes/Install.php:471
+msgid "My Portfolio"
+msgstr ""
+
+#: classes/Install.php:472
+msgid "My Portfolio Site"
+msgstr ""
+
+#: classes/Install.php:473
+msgid "This Portfolio is OPEN."
+msgstr ""
+
+#: classes/Install.php:474
+msgid "This Portfolio is OPEN, but only logged-in community members may view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:475
+msgid "This Portfolio is OPEN, but the corresponding Site is PRIVATE."
+msgstr ""
+
+#: classes/Install.php:476
+msgid "This Portfolio is PRIVATE."
+msgstr ""
+
+#: classes/Install.php:477
+msgid "This Portfolio is PRIVATE, but all logged-in community members may view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:478
+msgid "This Portfolio is PRIVATE, but the corresponding Site is OPEN to all visitors."
+msgstr ""
+
+#: classes/Install.php:479
+msgid "This Portfolio is PRIVATE, and you must be a member to view the corresponding Site."
+msgstr ""
+
+#: classes/Install.php:480
+#: classes/Install.php:481
+msgid "Visit Portfolio Site"
+msgstr ""
+
+#: classes/Install.php:482
+msgid "Each portfolio is associated with a WordPress site. The site is where portfolio owners display their work and accomplishments."
+msgstr ""
+
+#: classes/Install.php:483
+msgid "Take a moment to consider an address for the site associated with your portfolio. You will not be able to change it once you've created it."
+msgstr ""
+
+#: classes/Install.php:484
+msgid "Note: Please click the Check button to search for Post and Comment feeds for your external site. Doing so will push new activity to the portfolio page. If no feeds are detected, you may type in the Post and Comment feed URLs directly or just leave blank."
+msgstr ""
+
+#: classes/Install.php:485
+msgid "Portfolio Site"
+msgstr ""
+
+#: classes/Install.php:486
+#: lib/sidebar-funcs.php:308
+msgid "Portfolio Home"
+msgstr ""
+
+#: classes/Install.php:487
+msgid "These settings enable or disable the related links list display on your portfolio home page."
+msgstr ""
+
+#: classes/Install.php:488
+msgid "Invite Members to Portfolio"
+msgstr ""
+
+#: classes/Install.php:489
+msgid "Invite Community Members to Portfolio"
+msgstr ""
+
+#: classes/Install.php:490
+msgid "Search for Community Members to invite to your portfolio"
+msgstr ""
+
+#: classes/Install.php:491
+msgid "Porfolio Contact"
+msgstr ""
+
+#: classes/Install.php:492
+msgid "By default, you are the Portfolio Contact. You may add or remove Portfolio Contacts once your portfolio has more members."
+msgstr ""
+
+#: classes/Install.php:493
+msgid "Portfolio Discussion"
+msgstr ""
+
+#: classes/Install.php:564
+msgid "Academic"
+msgstr ""
+
+#: classes/Install.php:568
+msgid "Coursework"
+msgstr ""
+
+#: classes/Install.php:576
+msgid "Research"
+msgstr ""
+
+#: classes/Install.php:580
+msgid "Resource"
+msgstr ""
+
+#: classes/Install.php:610
+#: classes/Install.php:613
+msgid "Schools"
+msgstr ""
+
+#: classes/Install.php:612
+msgid "School"
+msgstr ""
+
+#: classes/Install.php:631
+#: classes/Install.php:634
+msgid "Departments"
+msgstr ""
+
+#: classes/Install.php:633
+msgid "Department"
+msgstr ""
+
+#: classes/Install.php:685
+msgid "Arts and Sciences"
+msgstr ""
+
+#: classes/Install.php:690
+msgid "English"
+msgstr ""
+
+#. translators: link to Dashboard > Pages > About
+#: classes/Install.php:726
+msgid "If you are the administrator, visit %s to modify this text."
+msgstr ""
+
+#: classes/Install.php:730
+msgid "Dashboard > Pages"
+msgstr ""
+
+#: classes/Install.php:737
+#: parts/sidebar/about.php:1
+#: parts/source/sidebar/about.php:12
+msgid "About"
+msgstr ""
+
+#: classes/Install.php:738
+#: includes/brand-settings.php:46
+msgid "This page can contain an introduction to your site, institution, and/or organization."
+msgstr ""
+
+#. Template Name of the theme
+#: classes/Install.php:741
+msgid "Help"
+msgstr ""
+
+#: classes/Install.php:742
+msgid "This section can contain help and support documentation, as well as answers to frequently asked questions for your site's members and visitors."
+msgstr ""
+
+#: classes/Install.php:745
+msgid "Terms of Use"
+msgstr ""
+
+#: classes/Install.php:746
+msgid "This page can contain the Terms of Service for your site. Terms of Service are the rules that a visitor or member must abide by while using your site."
+msgstr ""
+
+#: classes/Install.php:749
+msgid "Contact Us"
+msgstr ""
+
+#: classes/Install.php:750
+msgid "This page can contain contact information for the administrators of your site, which visitors to the site can use when they have questions, want to provide feedback, or need help."
+msgstr ""
+
+#. translators: 1: TOS URL, 2: TOS page title
+#: classes/Install.php:800
+msgid "By clicking \"Complete Sign Up\", you are agreeing to the <a href=\"%1$s\">%2$s</a>."
+msgstr ""
+
+#: classes/Install.php:843
+msgid "Use this space to highlight content from around your network."
+msgstr ""
+
+#: classes/Install.php:846
+msgid "Featured Item"
+msgstr ""
+
+#: classes/Install.php:852
+msgid "In The Spotlight"
+msgstr ""
+
+#: classes/Install.php:863
+#: lib/widgets/whats-happening.php:18
+msgid "What's Happening?"
+msgstr ""
+
+#: classes/Install.php:873
+#: lib/widgets/whos-online.php:18
+#: lib/widgets/whos-online.php:25
+msgid "Who's Online?"
+msgstr ""
+
+#: classes/Install.php:883
+#: lib/widgets/new-members.php:18
+#: lib/widgets/new-members.php:25
+msgid "New Members"
+msgstr ""
+
+#: classes/Install.php:891
+msgid "The footer areas can be used to display general information about your site, such as contact information and links to terms of service."
+msgstr ""
+
+#: classes/Install.php:898
+msgid "Footer area 1"
+msgstr ""
+
+#. translators: link to Customizer
+#: classes/Install.php:906
+msgid "Modify the text of this and other widgets using the <a href=\"%s\">Customizer</a>."
+msgstr ""
+
+#: classes/Install.php:913
+msgid "Footer area 2"
+msgstr ""
+
+#: classes/Install.php:1008
+#: functions.php:25
+#: functions.php:194
+#: lib/menus.php:12
+msgid "About Menu"
+msgstr ""
+
+#: classes/Install.php:1057
+msgid "Share Information Here"
+msgstr ""
+
+#: classes/Install.php:1058
+msgid "Site administrators can customize the slider area with images and text to welcome new members, highlight features, share important announcements, publicize events, and more."
+msgstr ""
+
+#: classes/Install.php:1062
+#: classes/Install.php:1128
+msgid "Welcome to CBOX OpenLab!"
+msgstr ""
+
+#. translators: link to CBOX OpenLab documentation
+#: classes/Install.php:1064
+#: classes/Install.php:1131
+msgid "Read our <a href=\"%s\">documentation</a> to learn more about how you can use CBOX OpenLab to create a commons for open learning."
+msgstr ""
+
+#: classes/Install.php:1132
+#: includes/network-toolbar.php:98
+#: functions.php:511
+msgid "CBOX-OL Logo"
+msgstr ""
+
+#: classes/Install.php:1141
+msgid "Customize this footer"
+msgstr ""
+
+#. translators: link to CBOX OpenLab Brand Settings admin page
+#: classes/Install.php:1144
+msgid "You can customize the contents of this footer to meet the needs of your community: see the <a href=\"%s\">Brand Settings documentation</a> for details."
+msgstr ""
+
+#: classes/MemberType.php:215
+#: classes/MemberType.php:219
+msgid "Signup code is incorrect."
+msgstr ""
+
+#: includes/academic-units.php:24
+msgctxt "Post type general name"
+msgid "Academic Unit Types"
+msgstr ""
+
+#: includes/academic-units.php:34
+msgctxt "Post type general name"
+msgid "Academic Units"
+msgstr ""
+
+#: includes/academic-units.php:117
+msgid "Academic Units allow your members to identify themselves and their groups with the appropriate divisions within your institution. Create the top-level unit types that best describe how your institution is organized - for example, Departments that are located within Divisions - and then define the specific units within each type. Members will then be able to associate themselves with these units when editing their profiles or when administering their groups."
+msgstr ""
+
+#: includes/academic-units.php:119
+msgid "Please choose whether this academic unit should be a required or optional choice, or not an available choice for any of the following member types."
+msgstr ""
+
+#: includes/academic-units.php:197
+msgid "No academic unit type found."
+msgstr ""
+
+#: includes/academic-units.php:265
+msgid "No academic unit found."
+msgstr ""
+
+#: includes/academic-units.php:535
+msgid "Please make sure you fill in all required fields before saving."
+msgstr ""
+
+#: includes/academic-units.php:536
+#: buddypress/groups/create.php:126
+#: buddypress/groups/create.php:154
+#: buddypress/groups/single/admin.php:47
+#: buddypress/groups/single/admin.php:50
+#: buddypress/members/register.php:58
+#: buddypress/members/register.php:112
+#: buddypress/members/register.php:131
+#: buddypress/members/register.php:172
+#: buddypress/members/single/profile/edit.php:63
+#: buddypress/members/single/profile/edit.php:65
+#: buddypress/members/single/profile/edit.php:74
+#: buddypress/members/single/profile/edit.php:83
+#: buddypress/members/single/profile/edit.php:92
+#: buddypress/members/single/profile/edit.php:106
+#: buddypress/members/single/profile/edit.php:120
+#: buddypress/members/single/profile/edit.php:130
+#: lib/member-funcs.php:629
+msgid "(required)"
+msgstr ""
+
+#: includes/admin.php:93
+msgctxt "\"Name\" label for adding new academic units"
+msgid "Name"
+msgstr ""
+
+#: includes/admin.php:94
+msgid "Define a parent/child relationship to indicate which category from the parent Academic Unit Type this new category should be associated with."
+msgstr ""
+
+#: includes/admin.php:95
+msgctxt "Header for Action column in admin tables"
+msgid "Action"
+msgstr ""
+
+#: includes/admin.php:96
+msgctxt "\"Add\" button text"
+msgid "Add"
+msgstr ""
+
+#: includes/admin.php:97
+msgid "Add email domain"
+msgstr ""
+
+#: includes/admin.php:98
+msgid "Add New Academic Unit"
+msgstr ""
+
+#: includes/admin.php:99
+msgid "Add New"
+msgstr ""
+
+#: includes/admin.php:100
+msgid "Add New Category"
+msgstr ""
+
+#: includes/admin.php:101
+msgctxt "placeholder for new item type form"
+msgid "Add New Type"
+msgstr ""
+
+#: includes/admin.php:102
+msgid "Associated with Group Types"
+msgstr ""
+
+#: includes/admin.php:103
+msgid "Associated with Member Types"
+msgstr ""
+
+#: includes/admin.php:104
+#: buddypress/docs/single/edit.php:128
+msgid "Cancel"
+msgstr ""
+
+#: includes/admin.php:105
+msgctxt "Column header for signup code value"
+msgid "Code"
+msgstr ""
+
+#: includes/admin.php:106
+msgid "Confirmation Text"
+msgstr ""
+
+#: includes/admin.php:107
+msgid "The text that appears just above the \"Complete Sign Up\" button on the registration form."
+msgstr ""
+
+#: includes/admin.php:108
+msgctxt "Column header"
+msgid "Count"
+msgstr ""
+
+#: includes/admin.php:109
+#: buddypress/docs/single/edit.php:131
+#: buddypress/groups/single/admin.php:520
+#: buddypress/groups/single/documents.php:67
+#: lib/menus.php:1041
+#: lib/plugin-mods/docs-funcs.php:160
+msgid "Delete"
+msgstr ""
+
+#: includes/admin.php:110
+msgid "Are you sure you want to delete this content?"
+msgstr ""
+
+#: includes/admin.php:111
+msgctxt "Domain from email domain whitelist"
+msgid "Domain"
+msgstr ""
+
+#: includes/admin.php:112
+#: includes/brand-settings.php:33
+#: buddypress/docs/docs-header.php:10
+#: buddypress/groups/single/documents.php:63
+msgid "Edit"
+msgstr ""
+
+#: includes/admin.php:113
+msgid "Editing"
+msgstr ""
+
+#: includes/admin.php:114
+msgid "Email Domain Whitelist"
+msgstr ""
+
+#: includes/admin.php:115
+msgid "To limit new user registrations to one or multiple email domains, include them here. Only users with emails matching the whitelisted domain(s) will be allowed to register for accounts. Wildcards are supported for multiple formats of the same base domain (e.g. *.schoolname.edu)."
+msgstr ""
+
+#: includes/admin.php:116
+msgid "Enter Signup Code"
+msgstr ""
+
+#: includes/admin.php:117
+msgid "Form Customization"
+msgstr ""
+
+#: includes/admin.php:118
+msgid "Use these settings to customize the registration form."
+msgstr ""
+
+#: includes/admin.php:119
+msgid "Save Form Customization Settings"
+msgstr ""
+
+#: includes/admin.php:120
+msgctxt "Column header for signup code table"
+msgid "Group"
+msgstr ""
+
+#: includes/admin.php:121
+msgctxt "item type Name label"
+msgid "Name"
+msgstr ""
+
+#: includes/admin.php:122
+msgctxt "subheader for item type labels"
+msgid "Labels"
+msgstr ""
+
+#: includes/admin.php:123
+msgid "Members may create courses"
+msgstr ""
+
+#: includes/admin.php:126
+msgid "Members may change Type to"
+msgstr ""
+
+#: includes/admin.php:127
+#: buddypress/members/single/profile/edit.php:176
+msgid "Member Type"
+msgstr ""
+
+#: includes/admin.php:129
+msgctxt "table header"
+msgid "Name"
+msgstr ""
+
+#: includes/admin.php:130
+msgctxt "radio button option"
+msgid "No"
+msgstr ""
+
+#: includes/admin.php:131
+msgid "Registration is currently open for all email domains. Enter one or more domains to restrict registration by email address."
+msgstr ""
+
+#: includes/admin.php:132
+msgctxt "null dropdown option"
+msgid "None"
+msgstr ""
+
+#: includes/admin.php:133
+msgid "Currently, users may select any Member Type when creating or editing their accounts. To restrict access to a Member Type, create a corresponding Signup Code below."
+msgstr ""
+
+#: includes/admin.php:134
+msgid "There are no units of this type."
+msgstr ""
+
+#: includes/admin.php:135
+msgctxt "disabled label for item type"
+msgid "(Off)"
+msgstr ""
+
+#: includes/admin.php:136
+msgid "On/off toggle"
+msgstr ""
+
+#: includes/admin.php:137
+msgid "Optional"
+msgstr ""
+
+#: includes/admin.php:138
+msgid "Used when displaying lists of types throughout the site."
+msgstr ""
+
+#: includes/admin.php:139
+msgid "Order"
+msgstr ""
+
+#: includes/admin.php:140
+#: buddypress/docs/single/edit.php:85
+msgid "Parent"
+msgstr ""
+
+#: includes/admin.php:142
+#: buddypress/docs/single/edit.php:128
+#: buddypress/groups/single/admin/ges-welcome-email.php:30
+msgid "Save"
+msgstr ""
+
+#: includes/admin.php:144
+msgid "Saved!"
+msgstr ""
+
+#: includes/admin.php:145
+msgid "Saving"
+msgstr ""
+
+#: includes/admin.php:146
+msgctxt "subheader for item type settings"
+msgid "Settings"
+msgstr ""
+
+#: includes/admin.php:147
+msgid "Select All"
+msgstr ""
+
+#: includes/admin.php:148
+msgid "Select Group"
+msgstr ""
+
+#: includes/admin.php:149
+msgid "Select Member Type"
+msgstr ""
+
+#: includes/admin.php:150
+msgctxt "checkbox screen reader text"
+msgid "Select Unit: %s"
+msgstr ""
+
+#: includes/admin.php:151
+msgid "Signup Code"
+msgstr ""
+
+#: includes/admin.php:152
+msgid "Sign Up Codes"
+msgstr ""
+
+#: includes/admin.php:153
+msgid "Registration codes let you restrict access to specific member account types (e.g faculty, staff, student). Each code can be associated with a group, so that users registering with the code will automatically be added to the group when their registration is complete. These account codes do not allow users to bypass the Email Domain Whitelist above."
+msgstr ""
+
+#: includes/admin.php:154
+msgctxt "subheader for template site settings section"
+msgid "Template"
+msgstr ""
+
+#: includes/admin.php:155
+msgctxt "template site dashboard link"
+msgid "Dashboard"
+msgstr ""
+
+#: includes/admin.php:156
+msgid "When a group of this type creates a site, default settings and data will be copied from the group type's template site. Use the links below to view and configure the template site."
+msgstr ""
+
+#: includes/admin.php:157
+msgctxt "template site view link"
+msgid "View Template"
+msgstr ""
+
+#: includes/admin.php:158
+msgid "Note: This Group Type is designed for Courses."
+msgstr ""
+
+#: includes/admin.php:159
+msgid "Note: This Group Type is designed for Portfolios."
+msgstr ""
+
+#: includes/admin.php:161
+msgctxt "radio button option"
+msgid "Yes"
+msgstr ""
+
+#: includes/admin.php:220
+msgctxt "Member Types admin label"
+msgid "Types"
+msgstr ""
+
+#: includes/admin.php:223
+msgctxt "Registration admin label"
+msgid "Registration"
+msgstr ""
+
+#: includes/admin.php:226
+msgctxt "Member profile fields admin label"
+msgid "Profile Fields"
+msgstr ""
+
+#: includes/admin.php:232
+msgctxt "Group Types admin label"
+msgid "Types"
+msgstr ""
+
+#: includes/admin.php:235
+msgctxt "Group categories admin label"
+msgid "Group Categories"
+msgstr ""
+
+#: includes/admin.php:241
+msgctxt "Communication Settings admin label"
+msgid "Email"
+msgstr ""
+
+#: includes/admin.php:244
+msgctxt "Communication Settings admin label"
+msgid "Invitations"
+msgstr ""
+
+#: includes/brand-settings.php:11
+msgid "Visual"
+msgstr ""
+
+#: includes/brand-settings.php:13
+msgid "Customize your site’s look, including the color scheme, custom logo, homepage layout, widgets and more."
+msgstr ""
+
+#: includes/brand-settings.php:16
+msgid "Customize"
+msgstr ""
+
+#: includes/brand-settings.php:22
+msgid "Copy"
+msgstr ""
+
+#: includes/brand-settings.php:24
+msgid "View and change the copy on your About, Help, Terms of Use, and other pages through the Edit and Preview links for each page below."
+msgstr ""
+
+#: includes/brand-settings.php:33
+msgid "Preview"
+msgstr ""
+
+#: includes/brand-settings.php:45
+msgid "About Page"
+msgstr ""
+
+#: includes/brand-settings.php:49
+msgid "Help Page"
+msgstr ""
+
+#: includes/brand-settings.php:50
+msgid "This section can contain help and support documentation and answers to frequently asked questions for your site’s members and visitors."
+msgstr ""
+
+#: includes/brand-settings.php:53
+msgid "Terms of Service"
+msgstr ""
+
+#: includes/brand-settings.php:54
+msgid "This page can contain the Terms of Service for your site. Terms of Service are the rules that a user must abide by while using your site."
+msgstr ""
+
+#: includes/brand-settings.php:58
+msgid "Contact Page"
+msgstr ""
+
+#: includes/brand-settings.php:59
+msgid "This page can contain contact information for the administrators of your site, which visitors to the site can use when they have questions, comments, or need help."
+msgstr ""
+
+#: includes/communication-settings.php:8
+msgid "Email Appearance"
+msgstr ""
+
+#: includes/communication-settings.php:13
+msgid "Customize the visual design of emails that will be sent to community members."
+msgstr ""
+
+#: includes/communication-settings.php:16
+msgid "Email Templates"
+msgstr ""
+
+#: includes/communication-settings.php:20
+msgid "Manage the content that’s included in emails sent automatically to members based on triggers (e.g. a welcome email sent to new members of a group)."
+msgstr ""
+
+#: includes/communication-settings.php:32
+msgid "Group Email Options"
+msgstr ""
+
+#: includes/communication-settings.php:36
+msgid "Update settings related to Daily Digests & Weekly Summaries of group activities in your community; toggle global unsubscribe links; modify group admin abilities related to email subscription settings; and establish spam prevention guidelines."
+msgstr ""
+
+#: includes/communication-settings.php:42
+msgid "Members of your community can be sent various notifications via email. Manage all settings related to emails here."
+msgstr ""
+
+#: includes/communication-settings.php:62
+msgid "Manage the invite email content template, control which member types are able to send various kinds of invitations, control address book integration, view sent invitations and related statistics."
+msgstr ""
+
+#: includes/communication-settings.php:68
+msgid "Invite Anyone allows community members to invite non-members to your community and its groups via email."
+msgstr ""
+
+#: includes/group-categories.php:36
+msgid "Group categories make it easier to organize and discover groups. Group administrators can add the categories you create here to their groups, which will then be filterable by category on group directory pages."
+msgstr ""
+
+#: includes/group-sites.php:413
+msgid "%1$s wrote a new blog post %2$s in the group %3$s"
+msgstr ""
+
+#: includes/group-sites.php:423
+msgid "%1$s commented on %2$s in the group %3$s"
+msgstr ""
+
+#. translators: 1. Post link, 2. Group link
+#: includes/group-sites.php:1026
+msgid "A new post %1$s was published in %2$s"
+msgstr ""
+
+#. translators: 1. Post link, 2. Group link
+#: includes/group-sites.php:1029
+msgid "A new comment was posted on the post %1$s in %2$s"
+msgstr ""
+
+#: includes/group-sites.php:1380
+msgid "Please Note: Posts and pages from the site you cloned are set to \"draft\" until you publish or delete them via <a href=\"%1$s\">Posts</a> and <a href=\"%2$s\">Pages</a>. Custom menus will need to be reactivated via <a href=\"%3$s\">Appearance > Menus</a>"
+msgstr ""
+
+#: includes/group-sites.php:1381
+msgid "Dismiss"
+msgstr ""
+
+#: includes/group-sites.php:1439
+msgid "Select a source blog."
+msgstr ""
+
+#: includes/group-sites.php:1458
+msgid ""
+"New site created by %1$1s\n"
+"\n"
+"Address: http://%2$2s\n"
+"Name: %3$3s"
+msgstr ""
+
+#: includes/group-sites.php:1462
+msgid "[%s] New Blog Created"
+msgstr ""
+
+#: includes/group-sites.php:1467
+msgid "Site Created"
+msgstr ""
+
+#: includes/group-sites.php:1582
+msgid "Blog Copied"
+msgstr ""
+
+#: includes/group-sites.php:1629
+msgid "Site names can only contain lowercase letters (a-z) and numbers."
+msgstr ""
+
+#: includes/group-sites.php:1676
+msgid "URLs can contain only alphanumeric characters, hyphens, and underscores."
+msgstr ""
+
+#: includes/group-sites.php:1678
+msgid "That site URL is already taken. Please try another."
+msgstr ""
+
+#: includes/group-sites.php:1680
+msgid "That URL is not allowed"
+msgstr ""
+
+#. translators: %s: minimum site name length
+#: includes/group-sites.php:1683
+msgid "Site name must be at least %s character."
+msgid_plural "Site name must be at least %s characters."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/group-types.php:85
+msgid "Group Types allow your site's groups to be categorized in various ways. Each group type gets its own directory, and groups of different types may differ in functionality and appearance."
+msgstr ""
+
+#: includes/group-types.php:103
+msgctxt "Post type general name"
+msgid "Group Types"
+msgstr ""
+
+#: includes/group-types.php:104
+msgctxt "Post type singular name"
+msgid "Group Type"
+msgstr ""
+
+#: includes/group-types.php:105
+msgid "Add New Group Type"
+msgstr ""
+
+#: includes/group-types.php:106
+msgid "New Group Type"
+msgstr ""
+
+#: includes/group-types.php:107
+msgid "Edit Group Type"
+msgstr ""
+
+#: includes/group-types.php:108
+msgid "View Group Type"
+msgstr ""
+
+#: includes/group-types.php:109
+msgid "All Group Types"
+msgstr ""
+
+#: includes/group-types.php:110
+msgid "Search Group Types"
+msgstr ""
+
+#: includes/group-types.php:111
+msgid "No group types found."
+msgstr ""
+
+#: includes/group-types.php:112
+msgid "No group types found in Trash."
+msgstr ""
+
+#: includes/group-types.php:155
+msgid "No group type found by that slug."
+msgstr ""
+
+#: includes/group-types.php:237
+msgid "This group does not have a type."
+msgstr ""
+
+#: includes/group-types.php:264
+msgid "No group type found."
+msgstr ""
+
+#: includes/member-types.php:15
+msgctxt "Post type general name"
+msgid "Member Types"
+msgstr ""
+
+#: includes/member-types.php:16
+msgctxt "Post type singular name"
+msgid "Member Type"
+msgstr ""
+
+#: includes/member-types.php:17
+msgid "Add New Member Type"
+msgstr ""
+
+#: includes/member-types.php:18
+msgid "New Member Type"
+msgstr ""
+
+#: includes/member-types.php:19
+msgid "Edit Member Type"
+msgstr ""
+
+#: includes/member-types.php:20
+msgid "View Member Type"
+msgstr ""
+
+#: includes/member-types.php:21
+msgid "All Member Types"
+msgstr ""
+
+#: includes/member-types.php:22
+msgid "Search Member Types"
+msgstr ""
+
+#: includes/member-types.php:23
+msgid "No member types found."
+msgstr ""
+
+#: includes/member-types.php:24
+msgid "No member types found in Trash."
+msgstr ""
+
+#: includes/member-types.php:68
+msgid "No member type exists for this slug."
+msgstr ""
+
+#: includes/member-types.php:163
+msgid "Member Types are used to organize your site’s users. Members are able to choose their own Member Type according to the rules that you configure on this page, as well as in <a href=\"%s\">Registration settings</a>."
+msgstr ""
+
+#: includes/member-types.php:184
+msgid "This user does not have a member type."
+msgstr ""
+
+#: includes/network-toolbar.php:9
+msgid "Red"
+msgstr ""
+
+#: includes/network-toolbar.php:13
+msgid "Blue"
+msgstr ""
+
+#: includes/network-toolbar.php:17
+msgid "Green"
+msgstr ""
+
+#: includes/network-toolbar.php:92
+msgid "Site Logo"
+msgstr ""
+
+#: includes/network-toolbar.php:128
+msgctxt "Home page banner link title"
+msgid "Home"
+msgstr ""
+
+#: includes/network-toolbar.php:132
+#: includes/network-toolbar.php:164
+msgid "Open Search"
+msgstr ""
+
+#: includes/network-toolbar.php:178
+msgid "Search by People or Group Type"
+msgstr ""
+
+#: includes/network-toolbar.php:179
+msgid "Select the Item Type to Search"
+msgstr ""
+
+#: includes/network-toolbar.php:180
+#: bbpress/form-reply.php:137
+#: bbpress/form-topic-merge.php:96
+#: bbpress/form-topic-split.php:98
+#: bbpress/form-topic.php:194
+#: buddypress/groups/single/documents.php:173
+msgid "Submit"
+msgstr ""
+
+#: includes/network-toolbar.php:181
+#: buddypress/docs/docs-loop.php:14
+#: buddypress/groups/index-directory.php:30
+#: buddypress/members/index-directory.php:18
+#: sidebar-group-archive.php:10
+#: sidebar-group-archive.php:179
+#: sidebar-group-archive.php:182
+msgid "Search"
+msgstr ""
+
+#: includes/network-toolbar.php:184
+msgid "People"
+msgstr ""
+
+#: includes/network-toolbar.php:423
+msgid "Menu"
+msgstr ""
+
+#: includes/network-toolbar.php:476
+#: includes/network-toolbar.php:1305
+#: lib/breadcrumbs.php:158
+#: lib/menus.php:719
+msgid "Home"
+msgstr ""
+
+#: includes/network-toolbar.php:528
+#: includes/network-toolbar.php:529
+#: includes/network-toolbar.php:549
+#: includes/network-toolbar.php:1399
+#: includes/network-toolbar.php:1400
+msgid "Hi, %1$s"
+msgstr ""
+
+#: includes/network-toolbar.php:553
+#: buddypress/activity/post-form.php:40
+#: lib/sidebar-funcs.php:265
+#: lib/theme-hooks.php:125
+#: parts/home/login.php:1
+#: parts/source/home/login.php:51
+msgid "My Profile"
+msgstr ""
+
+#: includes/network-toolbar.php:811
+#: includes/network-toolbar.php:868
+#: buddypress/groups/single/admin.php:472
+#: buddypress/members/single/friends/requests.php:30
+#: buddypress/members/single/groups/invites.php:26
+msgid "Accept"
+msgstr ""
+
+#: includes/network-toolbar.php:811
+#: includes/network-toolbar.php:868
+#: buddypress/groups/single/admin.php:473
+#: buddypress/members/single/friends/requests.php:31
+#: buddypress/members/single/groups/invites.php:27
+msgid "Reject"
+msgstr ""
+
+#: includes/network-toolbar.php:1073
+msgid "Network Admin: %s"
+msgstr ""
+
+#: includes/network-toolbar.php:1075
+msgid "Global Dashboard: %s"
+msgstr ""
+
+#: includes/network-toolbar.php:1098
+msgid "Visit Site"
+msgstr ""
+
+#: includes/network-toolbar.php:1106
+msgid "Edit Site"
+msgstr ""
+
+#: includes/network-toolbar.php:1228
+msgctxt "add new from admin bar"
+msgid "Link"
+msgstr ""
+
+#: includes/network-toolbar.php:1252
+msgctxt "add new from admin bar"
+msgid "User"
+msgstr ""
+
+#: includes/network-toolbar.php:1266
+msgctxt "admin bar menu group label"
+msgid "Add New"
+msgstr ""
+
+#: includes/network-toolbar.php:1308
+msgctxt "admin bar menu group label"
+msgid "Dashboard"
+msgstr ""
+
+#: includes/network-toolbar.php:1352
+msgid "%s comment awaiting moderation"
+msgid_plural "%s comments awaiting moderation"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/network-toolbar.php:1409
+msgid "My Account"
+msgstr ""
+
+#: includes/network-toolbar.php:1440
+msgid "Edit My Profile"
+msgstr ""
+
+#: includes/network-toolbar.php:1440
+#: parts/home/login.php:1
+#: parts/source/home/login.php:57
+msgid "Log Out"
+msgstr ""
+
+#: includes/network-toolbar.php:1476
+#: parts/home/login.php:1
+#: parts/source/home/login.php:76
+msgid "Sign Up"
+msgstr ""
+
+#: includes/portfolios.php:201
+msgid "%s's Portfolio"
+msgstr ""
+
+#: includes/profile-fields.php:11
+msgid "Profile fields can be customized to only be available to specific member types. Use the link below to access the Network Admin Dashboard to be able to specify which fields are available for each member type."
+msgstr ""
+
+#: includes/profile-fields.php:14
+msgid "Network Admin > Users > Profile Fields"
+msgstr ""
+
+#: includes/registration.php:18
+msgctxt "Post type general name"
+msgid "Signup Codes"
+msgstr ""
+
+#: includes/registration.php:74
+msgid "Registration management allows you to control who can create accounts and what types of accounts different types of users can create."
+msgstr ""
+
+#: includes/registration.php:205
+msgid "No signup code found."
+msgstr ""
+
+#: includes/registration.php:299
+msgid "No email provided."
+msgstr ""
+
+#: includes/registration.php:306
+msgid "Please enter a valid email address."
+msgstr ""
+
+#: includes/registration.php:311
+msgid "Sorry, that email address is not allowed!"
+msgstr ""
+
+#: includes/registration.php:316
+msgid "Sorry, that email address is already used!"
+msgstr ""
+
+#: includes/registration.php:460
+msgid "Click \"Complete Sign Up\" to continue."
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:104
+msgctxt "admin page title"
+msgid "Group Categories"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:104
+msgctxt "admin menu title"
+msgid "Group Categories"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:105
+msgctxt "admin page title"
+msgid "All Categories"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:105
+msgctxt "admin menu title"
+msgid "All Categories"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:109
+msgctxt "admin page title"
+msgid "Sort Group Categories"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:109
+msgctxt "admin menu title"
+msgid "Sort Group Categories"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:178
+msgid "Groups"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:211
+msgid "Cheatin&#8217; uh?"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:237
+msgid "Invalid taxonomy"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:300
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:316
+msgid "You attempted to edit an item that doesn&#8217;t exist. Perhaps it was deleted?"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/admin/class-bp-customizable-group-categories-admin.php:459
+msgid "An error has occurred. Please reload the page and try again."
+msgstr ""
+
+#: lib/bp-customizable-group-categories/includes/class-bp-customizable-group-categories.php:264
+msgid "BP Customizable Group Categories requires at least version %1$s of BuddyPress and version %2$s of WordPress."
+msgstr ""
+
+#: lib/bp-customizable-group-categories/includes/class-bp-customizable-group-categories.php:268
+msgid "BP Customizable Group Categories requires to be activated on the blog where BuddyPress is activated."
+msgstr ""
+
+#: lib/bp-customizable-group-categories/includes/class-bp-customizable-group-categories.php:359
+msgctxt "taxonomy general name"
+msgid "Group Categories"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/includes/class-bp-customizable-group-categories.php:360
+msgctxt "taxonomy singular name"
+msgid "Group Tag"
+msgstr ""
+
+#: lib/bp-customizable-group-categories/includes/term-metadata/term-metadata.php:34
+#: lib/bp-customizable-group-categories/includes/term-metadata/term-metadata.php:116
+msgid "Term meta cannot be added to terms that are shared between taxonomies."
+msgstr ""
+
+#: lib/bp-customizable-group-categories/parts/category-extra-fields.php:2
+msgid "Category Groups"
+msgstr ""
+
+#: plugins/pressforward.php:113
+msgid "Posted a comment on a PressForward feed item."
+msgstr ""
+
+#: plugins/pressforward.php:115
+msgid "PressForward Comments"
+msgstr ""
+
+#: plugins/pressforward.php:152
+#: plugins/pressforward.php:195
+msgid "%1$s posted a comment on the feed item %2$s on the site %3$s"
+msgstr ""
+
+#: templates/loginform.php:4
+#: buddypress/members/register.php:58
+#: parts/home/login.php:1
+#: parts/source/home/login.php:97
+msgid "Username"
+msgstr ""
+
+#: templates/loginform.php:5
+#: parts/home/login.php:1
+#: parts/source/home/login.php:100
+msgid "Password"
+msgstr ""
+
+#: templates/loginform.php:6
+msgid "Keep Me Logged In"
+msgstr ""
+
+#: templates/loginform.php:8
+#: parts/home/login.php:1
+#: parts/source/home/login.php:108
+msgid "Log In"
+msgstr ""
+
+#: templates/loginform.php:9
+#: parts/home/login.php:1
+#: parts/source/home/login.php:105
+msgid "Forgot Password?"
+msgstr ""
+
+#. Theme Name of the theme
+msgid "OpenLab"
+msgstr ""
+
+#. Description of the theme
+msgid "OpenLab Bootstrap based theme"
+msgstr ""
+
+#. Author of the theme
+msgid "CityTech OpenLab Dev Team"
+msgstr ""
+
+#. Author URI of the theme
+msgid "http://openlab.early-adopter.com"
+msgstr ""
+
+#: 404.php:22
+msgid "Page Not Found"
+msgstr ""
+
+#: 404.php:26
+msgid "The page you requested could not be found. Please use the menu above to find the page you need."
+msgstr ""
+
+#: bbpress/content-single-topic.php:41
+#: bbpress/form-reply.php:161
+msgid "The topic &#8216;%s&#8217; is closed to new replies."
+msgstr ""
+
+#: bbpress/content-single-topic.php:49
+#: bbpress/form-reply.php:173
+#: bbpress/form-topic.php:214
+msgid "The forum &#8216;%s&#8217; is closed to new topics and replies."
+msgstr ""
+
+#: bbpress/content-single-topic.php:57
+#: bbpress/form-reply.php:185
+msgid "You cannot reply to this topic."
+msgstr ""
+
+#: bbpress/content-single-topic.php:57
+#: bbpress/form-reply.php:185
+msgid "You must be logged in to reply to this topic."
+msgstr ""
+
+#: bbpress/form-reply.php:27
+msgid "Reply To: %s"
+msgstr ""
+
+#: bbpress/form-reply.php:35
+msgid "This topic is marked as closed to new replies, however your posting capabilities still allow you to do so."
+msgstr ""
+
+#: bbpress/form-reply.php:43
+#: bbpress/form-topic.php:60
+msgid "Your account has the ability to post unrestricted HTML content."
+msgstr ""
+
+#: bbpress/form-reply.php:63
+#: bbpress/form-topic.php:89
+msgid "You may use these <abbr title=\"HyperText Markup Language\">HTML</abbr> tags and attributes:"
+msgstr ""
+
+#: bbpress/form-reply.php:74
+msgid "Tags:"
+msgstr ""
+
+#: bbpress/form-reply.php:92
+#: bbpress/form-topic.php:151
+msgid "Notify the author of follow-up replies via email"
+msgstr ""
+
+#: bbpress/form-reply.php:96
+#: bbpress/form-topic.php:155
+msgid "Notify me of follow-up replies via email"
+msgstr ""
+
+#: bbpress/form-reply.php:113
+#: bbpress/form-topic.php:171
+msgid "Keep a log of this edit:"
+msgstr ""
+
+#: bbpress/form-reply.php:117
+#: bbpress/form-topic.php:175
+msgid "Optional reason for editing:"
+msgstr ""
+
+#: bbpress/form-topic-merge.php:24
+msgid "Merge topic \"%s\""
+msgstr ""
+
+#: bbpress/form-topic-merge.php:29
+msgid "Select the topic to merge this one into. The destination topic will remain the lead topic, and this one will change into a reply."
+msgstr ""
+
+#: bbpress/form-topic-merge.php:30
+msgid "To keep this topic as the lead, go to the other topic and use the merge tool from there instead."
+msgstr ""
+
+#: bbpress/form-topic-merge.php:34
+msgid "All replies within both topics will be merged chronologically. The order of the merged replies is based on the time and date they were posted. If the destination topic was created after this one, it's post date will be updated to second earlier than this one."
+msgstr ""
+
+#: bbpress/form-topic-merge.php:38
+msgid "Destination"
+msgstr ""
+
+#: bbpress/form-topic-merge.php:42
+msgid "Merge with this topic:"
+msgstr ""
+
+#: bbpress/form-topic-merge.php:56
+msgid "There are no other topics in this forum to merge with."
+msgstr ""
+
+#: bbpress/form-topic-merge.php:64
+#: bbpress/form-topic-split.php:66
+msgid "Topic Extras"
+msgstr ""
+
+#: bbpress/form-topic-merge.php:71
+msgid "Merge topic subscribers"
+msgstr ""
+
+#: bbpress/form-topic-merge.php:76
+msgid "Merge topic favoriters"
+msgstr ""
+
+#: bbpress/form-topic-merge.php:81
+msgid "Merge topic tags"
+msgstr ""
+
+#: bbpress/form-topic-merge.php:92
+#: bbpress/form-topic-split.php:94
+msgid "<strong>WARNING:</strong> This process cannot be undone."
+msgstr ""
+
+#: bbpress/form-topic-merge.php:109
+#: bbpress/form-topic-split.php:109
+msgid "You do not have the permissions to edit this topic!"
+msgstr ""
+
+#: bbpress/form-topic-merge.php:109
+#: bbpress/form-topic-split.php:109
+msgid "You cannot edit this topic."
+msgstr ""
+
+#: bbpress/form-topic-split.php:22
+msgid "Split topic \"%s\""
+msgstr ""
+
+#: bbpress/form-topic-split.php:27
+msgid "When you split a topic, you are slicing it in half starting with the reply you just selected. Choose to use that reply as a new topic with a new title, or merge those replies into an existing topic."
+msgstr ""
+
+#: bbpress/form-topic-split.php:31
+msgid "If you use the existing topic option, replies within both topics will be merged chronologically. The order of the merged replies is based on the time and date they were posted."
+msgstr ""
+
+#: bbpress/form-topic-split.php:35
+msgid "Split Method"
+msgstr ""
+
+#: bbpress/form-topic-split.php:39
+msgid "New topic in <strong>%s</strong> titled:"
+msgstr ""
+
+#: bbpress/form-topic-split.php:40
+msgid "Split: %s"
+msgstr ""
+
+#: bbpress/form-topic-split.php:47
+msgid "Use an existing topic in this forum:"
+msgstr ""
+
+#: bbpress/form-topic-split.php:73
+msgid "Copy subscribers to the new topic"
+msgstr ""
+
+#: bbpress/form-topic-split.php:78
+msgid "Copy favoriters to the new topic"
+msgstr ""
+
+#: bbpress/form-topic-split.php:83
+msgid "Copy topic tags to the new topic"
+msgstr ""
+
+#: bbpress/form-topic.php:37
+msgid "Now Editing &ldquo;%s&rdquo;"
+msgstr ""
+
+#: bbpress/form-topic.php:39
+msgid "Create New Topic in &ldquo;%s&rdquo;"
+msgstr ""
+
+#: bbpress/form-topic.php:39
+msgid "Create New Topic"
+msgstr ""
+
+#: bbpress/form-topic.php:74
+msgid "Topic Title (Maximum Length: %d):"
+msgstr ""
+
+#: bbpress/form-topic.php:100
+msgid "Topic Tags:"
+msgstr ""
+
+#: bbpress/form-topic.php:120
+msgid "Topic Type:"
+msgstr ""
+
+#: bbpress/form-topic.php:132
+msgid "Topic Status:"
+msgstr ""
+
+#: bbpress/form-topic.php:222
+msgid "You cannot create new topics."
+msgstr ""
+
+#: bbpress/form-topic.php:222
+msgid "You must be logged in to create new topics."
+msgstr ""
+
+#: bbpress/loop-single-reply.php:21
+msgid "in reply to: "
+msgstr ""
+
+#: bbpress/loop-single-topic.php:63
+msgid "Started by: %1$s"
+msgstr ""
+
+#: bbpress/loop-single-topic.php:71
+msgid "in: <a href=\"%1$s\">%2$s</a>"
+msgstr ""
+
+#: buddypress/activity/activity-loop.php:27
+msgid "Load More"
+msgstr ""
+
+#: buddypress/activity/activity-loop.php:37
+msgid "Sorry, there was no activity found. Please try a different filter."
+msgstr ""
+
+#: buddypress/activity/entry.php:28
+msgid "Reply"
+msgstr ""
+
+#: buddypress/activity/entry.php:33
+msgid "Mark as Favorite"
+msgstr ""
+
+#: buddypress/activity/entry.php:33
+msgid "Favorite"
+msgstr ""
+
+#: buddypress/activity/entry.php:35
+msgid "Remove Favorite"
+msgstr ""
+
+#: buddypress/activity/entry.php:45
+msgid "In reply to"
+msgstr ""
+
+#: buddypress/activity/entry.php:46
+msgid "View Thread / Permalink"
+msgstr ""
+
+#: buddypress/activity/entry.php:46
+msgid "View"
+msgstr ""
+
+#: buddypress/activity/entry.php:63
+msgid "Post"
+msgstr ""
+
+#: buddypress/activity/entry.php:63
+msgid "or press esc to cancel."
+msgstr ""
+
+#: buddypress/activity/index.php:7
+msgid "Site Activity"
+msgstr ""
+
+#: buddypress/activity/index.php:22
+msgid "The public activity for everyone on this site."
+msgstr ""
+
+#: buddypress/activity/index.php:22
+msgid "All Members (%s)"
+msgstr ""
+
+#: buddypress/activity/index.php:30
+msgid "The activity of my friends only."
+msgstr ""
+
+#: buddypress/activity/index.php:30
+msgid "My Friends (%s)"
+msgstr ""
+
+#: buddypress/activity/index.php:38
+msgid "The activity of groups I am a member of."
+msgstr ""
+
+#: buddypress/activity/index.php:38
+msgid "My Groups (%s)"
+msgstr ""
+
+#: buddypress/activity/index.php:45
+msgid "The activity I've marked as a favorite."
+msgstr ""
+
+#: buddypress/activity/index.php:45
+msgid "My Favorites (<span>%s</span>)"
+msgstr ""
+
+#: buddypress/activity/index.php:50
+msgid "Activity that I have been mentioned in."
+msgstr ""
+
+#: buddypress/activity/index.php:50
+msgid "@%s Mentions"
+msgstr ""
+
+#: buddypress/activity/index.php:50
+msgid "(%s new)"
+msgstr ""
+
+#: buddypress/activity/index.php:60
+#: buddypress/groups/single/activity.php:4
+msgid "RSS Feed"
+msgstr ""
+
+#: buddypress/activity/index.php:60
+#: buddypress/groups/single/activity.php:4
+msgid "RSS"
+msgstr ""
+
+#: buddypress/activity/index.php:66
+#: buddypress/groups/single/activity.php:10
+msgid "No Filter"
+msgstr ""
+
+#: buddypress/activity/index.php:67
+#: buddypress/groups/single/activity.php:11
+msgid "Show Updates"
+msgstr ""
+
+#: buddypress/activity/index.php:70
+msgid "Show Blog Posts"
+msgstr ""
+
+#: buddypress/activity/index.php:71
+msgid "Show Blog Comments"
+msgstr ""
+
+#: buddypress/activity/index.php:75
+#: buddypress/groups/single/activity.php:14
+msgid "Show New Forum Topics"
+msgstr ""
+
+#: buddypress/activity/index.php:76
+#: buddypress/groups/single/activity.php:15
+msgid "Show Forum Replies"
+msgstr ""
+
+#: buddypress/activity/index.php:80
+msgid "Show New Groups"
+msgstr ""
+
+#: buddypress/activity/index.php:81
+#: buddypress/groups/single/activity.php:18
+msgid "Show New Group Memberships"
+msgstr ""
+
+#: buddypress/activity/index.php:85
+msgid "Show Friendship Connections"
+msgstr ""
+
+#: buddypress/activity/index.php:88
+msgid "Show New Members"
+msgstr ""
+
+#: buddypress/activity/post-form.php:7
+msgid "You are mentioning %s in a new update, this user will be sent a notification of your message."
+msgstr ""
+
+#: buddypress/activity/post-form.php:21
+msgid "What's new %s?"
+msgstr ""
+
+#: buddypress/activity/post-form.php:33
+msgid "Post Update"
+msgstr ""
+
+#: buddypress/activity/post-form.php:37
+msgid "Post in"
+msgstr ""
+
+#: buddypress/docs/docs-header.php:5
+msgid "Read"
+msgstr ""
+
+#: buddypress/docs/docs-loop.php:29
+#: buddypress/docs/single/edit.php:40
+msgid "Title"
+msgstr ""
+
+#: buddypress/docs/docs-loop.php:33
+#: buddypress/docs/docs-loop.php:66
+#: lib/group-funcs.php:381
+#: lib/group-funcs.php:462
+msgid "Author"
+msgstr ""
+
+#: buddypress/docs/docs-loop.php:37
+msgid "Created"
+msgstr ""
+
+#: buddypress/docs/docs-loop.php:41
+msgid "Last Edited"
+msgstr ""
+
+#: buddypress/docs/docs-loop.php:44
+#: buddypress/docs/single/edit.php:64
+msgid "Tags"
+msgstr ""
+
+#: buddypress/docs/docs-loop.php:104
+msgid "Viewing %1$s-%2$s of %3$s docs"
+msgstr ""
+
+#: buddypress/docs/docs-loop.php:114
+msgid "There are no docs to view. Why not <a href=\"%s\">create one</a>?"
+msgstr ""
+
+#: buddypress/docs/docs-loop.php:116
+msgid "There are no docs to view."
+msgstr ""
+
+#: buddypress/docs/single/edit.php:29
+msgid "You have been idle for <span id=\"idle-warning-time\"></span>"
+msgstr ""
+
+#: buddypress/docs/single/edit.php:46
+msgid "Permalink"
+msgstr ""
+
+#: buddypress/docs/single/edit.php:52
+#: lib/customizer.php:137
+#: lib/customizer.php:169
+msgid "Content"
+msgstr ""
+
+#: buddypress/docs/single/edit.php:70
+msgid "Tags are words or phrases that help to describe and organize your Docs."
+msgstr ""
+
+#: buddypress/docs/single/edit.php:71
+msgid "Separate tags with commas (for example: <em>orchestra, snare drum, piccolo, Brahms</em>)"
+msgstr ""
+
+#: buddypress/docs/single/edit.php:91
+msgid "Select a parent for this Doc."
+msgstr ""
+
+#: buddypress/docs/single/edit.php:93
+msgid "(Optional) Assigning a parent Doc means that a link to the parent will appear at the bottom of this Doc, and a link to this Doc will appear at the bottom of the parent."
+msgstr ""
+
+#: buddypress/docs/single/edit.php:163
+msgid "Are you still there?"
+msgstr ""
+
+#: buddypress/docs/single/edit.php:165
+msgid "In order to prevent overwriting content, only one person can edit a given doc at a time. For that reason, you must periodically ensure the system that you're still actively editing. If you are idle for more than 30 minutes, your changes will be auto-saved, and you'll be sent out of Edit mode so that others can access the doc."
+msgstr ""
+
+#: buddypress/docs/single/edit.php:168
+msgid "I'm still editing!"
+msgstr ""
+
+#: buddypress/docs/single/index.php:5
+msgid "Locked"
+msgstr ""
+
+#: buddypress/docs/single/index.php:5
+msgid "(click for more info)"
+msgstr ""
+
+#: buddypress/docs/single/index.php:7
+msgid "This doc is currently being edited by %1$s. In order to prevent edit conflicts, only one user can edit a doc at a time."
+msgstr ""
+
+#: buddypress/docs/single/index.php:10
+msgid "Please try again in a few minutes. Or, as an admin, you can <a href=\"%s\">force cancel</a> the edit lock."
+msgstr ""
+
+#: buddypress/docs/single/index.php:12
+msgid "Please try again in a few minutes."
+msgstr ""
+
+#: buddypress/groups/create.php:79
+msgid "Create New or Clone Existing?"
+msgstr ""
+
+#: buddypress/groups/create.php:87
+#: buddypress/groups/index-directory.php:14
+#: lib/menus.php:482
+msgid "Create New"
+msgstr ""
+
+#: buddypress/groups/create.php:103
+msgid "Clone Existing"
+msgstr ""
+
+#: buddypress/groups/create.php:105
+msgid "Choose Clone Source"
+msgstr ""
+
+#: buddypress/groups/create.php:126
+#: buddypress/groups/single/admin.php:47
+#: buddypress/groups/single/admin.php:160
+msgid "Name"
+msgstr ""
+
+#: buddypress/groups/create.php:135
+msgid "FirstName LastName's Portfolio"
+msgstr ""
+
+#: buddypress/groups/create.php:136
+msgid "Jane Smith's Portfolio (Example)"
+msgstr ""
+
+#: buddypress/groups/create.php:185
+msgid "Previous Step"
+msgstr ""
+
+#: buddypress/groups/create.php:190
+msgid "Next Step"
+msgstr ""
+
+#: buddypress/groups/create.php:195
+msgid "Create and Continue"
+msgstr ""
+
+#: buddypress/groups/create.php:200
+msgid "Finish"
+msgstr ""
+
+#: buddypress/groups/groups-loop.php:180
+msgid "There are no items to display"
+msgstr ""
+
+#: buddypress/groups/index-directory.php:14
+#: lib/menus.php:477
+msgid "Create / Clone"
+msgstr ""
+
+#. Template Name of the theme
+msgid "My Group Template"
+msgstr ""
+
+#: buddypress/groups/index.php:17
+#: lib/member-funcs.php:482
+msgid "%s&rsquo;s Profile"
+msgstr ""
+
+#: buddypress/groups/index.php:20
+#: lib/group-funcs.php:1185
+#: lib/member-funcs.php:487
+#: lib/nav.php:134
+#: page.php:29
+msgid "Toggle navigation"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:22
+msgid "Settings:"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:42
+msgid "Details"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:57
+msgid "Notify group members of changes via email"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:94
+msgid "Discussion, Docs, and Files Settings"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:98
+msgid "Enable Discussion"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:101
+msgid "Enable Docs"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:104
+msgid "Enable Files"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:117
+msgid "Calendar Settings"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:124
+msgid "Enable Calendar"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:144
+msgid "Related Links List Settings"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:151
+msgid "Enable related links list"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:153
+#: buddypress/groups/single/admin.php:188
+msgid "List Heading"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:163
+msgid "URL"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:178
+msgid "Portfolio List Settings"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:185
+msgid "Enable portfolio list"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:221
+#: lib/group-funcs.php:642
+msgid "Upload Avatar"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:242
+msgid "Upload an image to use as an avatar for this group. The image will be shown on the Profile and in search results."
+msgstr ""
+
+#: buddypress/groups/single/admin.php:249
+#: buddypress/members/single/profile/change-avatar.php:32
+#: lib/group-funcs.php:669
+msgid "Upload Image"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:255
+msgid "If you'd like to remove the existing avatar but not upload a new one, please use the delete avatar button."
+msgstr ""
+
+#: buddypress/groups/single/admin.php:256
+#: buddypress/members/single/profile/change-avatar.php:39
+msgid "Delete Avatar"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:270
+msgid "Crop Avatar"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:273
+#: buddypress/members/single/profile/change-avatar.php:54
+msgid "Avatar to crop"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:276
+#: buddypress/members/single/profile/change-avatar.php:57
+msgid "Avatar preview"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:279
+#: buddypress/members/single/profile/change-avatar.php:60
+msgid "Crop Image"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:303
+msgid "Administrators"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:322
+#: buddypress/groups/single/admin.php:358
+msgid "Demote to Member"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:339
+msgid "Moderators"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:349
+#: buddypress/groups/single/admin.php:401
+msgid "Profile picture of %s"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:357
+#: buddypress/groups/single/admin.php:417
+msgid "Promote to Admin"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:374
+msgid "Members"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:402
+msgid "(banned)"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:411
+msgid "Unban this member"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:411
+msgid "Remove Ban"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:415
+msgid "Kick and ban this member"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:415
+msgid "Kick &amp; Ban"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:416
+msgid "Promote to Mod"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:421
+msgid "Remove this member"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:421
+msgid "Remove from group"
+msgstr ""
+
+#: buddypress/groups/single/admin.php:437
+#: buddypress/groups/single/members.php:65
+#: lib/group-funcs.php:1400
+msgid "This group has no members."
+msgstr ""
+
+#: buddypress/groups/single/admin.php:486
+msgid "There are no pending membership requests."
+msgstr ""
+
+#: buddypress/groups/single/admin.php:503
+msgid "WARNING: Deleting this item will completely remove ALL content associated with it. There is no way back, please be careful with this option."
+msgstr ""
+
+#: buddypress/groups/single/admin.php:513
+msgid "I understand the consequences of deletion."
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-email-notice.php:3
+msgid "Send an email notice to all members of \"%s\""
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-email-notice.php:6
+msgid "You can use the form below to send an email notice to all members of \"%s\"."
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-email-notice.php:7
+msgid "Members will receive the notice regardless of email settings, so please use with caution"
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-email-notice.php:10
+#: buddypress/groups/single/admin/ges-welcome-email.php:20
+msgid "Email Subject:"
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-email-notice.php:15
+#: buddypress/groups/single/admin/ges-welcome-email.php:25
+msgid "Email Content:"
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-email-notice.php:20
+msgid "Send Notice"
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-welcome-email.php:7
+msgid "Welcome Email"
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-welcome-email.php:10
+msgid "Send an email when a new member joins \"%s\"."
+msgstr ""
+
+#: buddypress/groups/single/admin/ges-welcome-email.php:15
+msgid "Enable welcome email"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:19
+#: buddypress/groups/single/documents.php:177
+msgid "Category:"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:21
+#: sidebar-group-archive.php:108
+#: sidebar-group-archive.php:127
+#: sidebar-group-archive.php:144
+msgid "All"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:26
+#: buddypress/groups/single/documents.php:42
+msgid "Go"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:36
+msgid "Order by:"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:38
+msgid "Newest"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:39
+msgid "Alphabetical"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:40
+msgid "Most Popular"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:83
+msgid "Uploaded by %1$s on %2$s"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:97
+msgid "There are no files to view."
+msgstr ""
+
+#: buddypress/groups/single/documents.php:127
+#: buddypress/groups/single/documents.php:196
+msgid "Upload a New File"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:129
+msgid "Edit File"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:148
+msgid "Choose File:"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:156
+msgid "Featured File"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:162
+msgid "Display Name:"
+msgstr ""
+
+#: buddypress/groups/single/documents.php:165
+msgid "Description:"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:14
+msgid "New Topic"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:24
+msgid "Order By:"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:26
+msgid "Last Active"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:27
+msgid "Most Posts"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:28
+msgid "Unreplied"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:53
+msgid "Post a New Topic:"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:58
+msgid "You will auto join this group when you start a new topic."
+msgstr ""
+
+#: buddypress/groups/single/forum.php:63
+#: lib/widgets/group-type.php:98
+#: lib/widgets/new-members.php:100
+#: lib/widgets/whats-happening.php:118
+#: lib/widgets/whos-online.php:116
+msgid "Title:"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:66
+msgid "Content:"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:69
+msgid "Tags (comma separated):"
+msgstr ""
+
+#: buddypress/groups/single/forum.php:77
+msgid "Post Topic"
+msgstr ""
+
+#: buddypress/groups/single/group-home.php:116
+#: lib/group-funcs.php:2577
+#: sidebar-group-archive.php:143
+msgid "Term"
+msgstr ""
+
+#: buddypress/groups/single/group-home.php:123
+#: parts/forms/group-categories.php:1
+#: parts/source/forms/group-categories.php:2
+#: sidebar-group-archive.php:126
+msgid "Category"
+msgstr ""
+
+#: buddypress/groups/single/group-home.php:130
+msgid "Course Description"
+msgstr ""
+
+#: buddypress/groups/single/group-home.php:188
+msgid "Member Profile"
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:34
+msgid "Start typing a few letters of member's display name. When a dropdown list appears, select from the list."
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:51
+#: buddypress/groups/single/send-invites.php:42
+msgid "Remove Invite"
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:65
+msgid "These members will be sent an invitation."
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:68
+msgid "Click 'Finish' to continue."
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:70
+msgid "Click the \"Send Invites\" button to continue."
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:78
+#: buddypress/groups/single/send-invites.php:60
+#: lib/plugin-mods/invite-funcs.php:225
+msgid "Send Invites"
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:90
+msgid "Invite new members by email:"
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:93
+msgid "This link will take you to My Invitations, where you may invite people to join the community and this group."
+msgstr ""
+
+#: buddypress/groups/single/invite-anyone.php:95
+msgid "Invite New Members to This Community"
+msgstr ""
+
+#: buddypress/groups/single/plugins.php:37
+#: lib/menus.php:130
+msgid "Files"
+msgstr ""
+
+#: buddypress/groups/single/request-membership.php:6
+msgid "You are requesting to become a member of '%s'."
+msgstr ""
+
+#: buddypress/groups/single/request-membership.php:9
+msgid "Comments (optional)"
+msgstr ""
+
+#: buddypress/groups/single/request-membership.php:14
+msgid "Send Request"
+msgstr ""
+
+#: buddypress/groups/single/send-invites.php:22
+msgid "Select people to invite from your friends list."
+msgstr ""
+
+#: buddypress/groups/single/send-invites.php:73
+msgid "Once you have built up friend connections you will be able to invite others to your group. You can send invites any time in the future by selecting the \"Send Invites\" option when viewing your new group."
+msgstr ""
+
+#: buddypress/members/activate.php:17
+msgid "Account Activated"
+msgstr ""
+
+#: buddypress/members/activate.php:26
+msgid "Your account was activated successfully! Your account details have been sent to you in a separate email."
+msgstr ""
+
+#: buddypress/members/activate.php:28
+msgid "Your account was activated successfully! You can now log in with the username and password you provided when you signed up."
+msgstr ""
+
+#: buddypress/members/activate.php:35
+msgid "Activate your Account"
+msgstr ""
+
+#: buddypress/members/activate.php:41
+msgid "Please provide a valid activation key."
+msgstr ""
+
+#: buddypress/members/activate.php:44
+msgid "Activation Key:"
+msgstr ""
+
+#. Template Name of the theme
+msgid "People Archive"
+msgstr ""
+
+#: buddypress/members/members-loop.php:67
+msgid "Sorry, no members were found."
+msgstr ""
+
+#: buddypress/members/register.php:24
+msgid "Allowed email domains: %s"
+msgstr ""
+
+#: buddypress/members/register.php:38
+msgid "Create an Account"
+msgstr ""
+
+#: buddypress/members/register.php:46
+msgid "Account Details"
+msgstr ""
+
+#: buddypress/members/register.php:51
+msgid "Registering for %s is easy. Just fill in the fields below and we'll get a new account set up for you in no time."
+msgstr ""
+
+#: buddypress/members/register.php:58
+msgid "(lowercase & no special characters)"
+msgstr ""
+
+#: buddypress/members/register.php:74
+msgid "That username is already taken."
+msgstr ""
+
+#: buddypress/members/register.php:79
+msgid "Email Address (required)"
+msgstr ""
+
+#: buddypress/members/register.php:95
+msgid "Confirm Email Address (required)"
+msgstr ""
+
+#: buddypress/members/register.php:106
+msgid "Email addresses must match."
+msgstr ""
+
+#: buddypress/members/register.php:112
+msgid "Choose a Password"
+msgstr ""
+
+#: buddypress/members/register.php:131
+msgid "Confirm Password"
+msgstr ""
+
+#: buddypress/members/register.php:143
+msgid "Passwords must match."
+msgstr ""
+
+#: buddypress/members/register.php:156
+msgid "Public Profile Details"
+msgstr ""
+
+#: buddypress/members/register.php:163
+msgid "Your responses in the form fields below will be displayed on your profile page, which is open to the public. You can always add, edit, or remove information at a later date."
+msgstr ""
+
+#: buddypress/members/register.php:172
+msgid "Account Type"
+msgstr ""
+
+#: buddypress/members/register.php:176
+msgid "- Select Account Type -"
+msgstr ""
+
+#: buddypress/members/register.php:184
+msgid "Please enter a sign up code"
+msgstr ""
+
+#: buddypress/members/register.php:216
+msgid "Please Complete Required Fields"
+msgstr ""
+
+#: buddypress/members/register.php:228
+msgid "Sign Up Complete!"
+msgstr ""
+
+#: buddypress/members/register.php:234
+msgid "You have successfully created your account! To begin using this site you will need to activate your account via the email we have just sent to your address."
+msgstr ""
+
+#: buddypress/members/register.php:236
+msgid "You have successfully created your account! Please log in using the username and password you have just created."
+msgstr ""
+
+#: buddypress/members/single/friends/requests.php:49
+msgid "You have no pending friendship requests."
+msgstr ""
+
+#: buddypress/members/single/groups/invites.php:44
+msgid "You have no outstanding group invites."
+msgstr ""
+
+#: buddypress/members/single/header.php:66
+#: buddypress/members/single/profile/edit.php:47
+#: lib/menus.php:431
+msgid "Edit Profile"
+msgstr ""
+
+#: buddypress/members/single/header.php:67
+#: lib/menus.php:432
+msgid "Change Avatar"
+msgstr ""
+
+#: buddypress/members/single/header.php:81
+msgid "Send a private message to this user."
+msgstr ""
+
+#: buddypress/members/single/header.php:82
+msgid "<i class=\"fa fa-envelope\" aria-hidden=\"true\"></i> Send Message"
+msgstr ""
+
+#: buddypress/members/single/member-home.php:48
+#: buddypress/members/single/member-home.php:72
+#: lib/menus.php:566
+#: lib/menus.php:656
+msgid "My Friends"
+msgstr ""
+
+#: buddypress/members/single/member-home.php:48
+#: buddypress/members/single/member-home.php:72
+#: lib/menus.php:566
+msgid "%s's Friends"
+msgstr ""
+
+#: buddypress/members/single/member-home.php:75
+msgid "You haven't added any friend connections yet."
+msgstr ""
+
+#: buddypress/members/single/member-home.php:75
+msgid "%s hasn't created any friend connections yet."
+msgstr ""
+
+#: buddypress/members/single/messages/compose.php:9
+msgid "Send To (Username or Friend's Name)"
+msgstr ""
+
+#: buddypress/members/single/messages/compose.php:19
+msgid "This is a notice to all users."
+msgstr ""
+
+#: buddypress/members/single/messages/compose.php:23
+msgid "Subject"
+msgstr ""
+
+#: buddypress/members/single/messages/compose.php:26
+msgid "Message"
+msgstr ""
+
+#: buddypress/members/single/messages/compose.php:36
+msgid "Send Message"
+msgstr ""
+
+#: buddypress/members/single/messages/messages-loop.php:27
+#: buddypress/members/single/messages/messages-loop.php:38
+msgid "View Message"
+msgstr ""
+
+#: buddypress/members/single/messages/messages-loop.php:30
+msgid "From:"
+msgstr ""
+
+#: buddypress/members/single/messages/messages-loop.php:32
+msgid "To:"
+msgstr ""
+
+#: buddypress/members/single/messages/messages-loop.php:73
+msgid "Sorry, no messages were found."
+msgstr ""
+
+#: buddypress/members/single/messages/notices-loop.php:31
+msgid "Sent:"
+msgstr ""
+
+#: buddypress/members/single/messages/notices-loop.php:38
+msgid "Delete Message"
+msgstr ""
+
+#: buddypress/members/single/messages/notices-loop.php:49
+msgid "Sorry, no notices were found."
+msgstr ""
+
+#: buddypress/members/single/messages/single.php:11
+msgid "Sent between %1$s"
+msgstr ""
+
+#: buddypress/members/single/messages/single.php:66
+msgid "Send a Reply"
+msgstr ""
+
+#: buddypress/members/single/messages/single.php:84
+msgid "Send Reply"
+msgstr ""
+
+#: buddypress/members/single/profile/change-avatar.php:25
+msgid "Your avatar will be used on your profile and throughout the site. If there is a Gravatar associated with your account email we will use that, or you can upload an image from your computer. Click below to select a JPG, GIF or PNG format photo from your computer and then click \"Upload Image\" to proceed."
+msgstr ""
+
+#: buddypress/members/single/profile/change-avatar.php:38
+msgid "If you'd like to delete your current avatar but not upload a new one, please use the delete avatar button."
+msgstr ""
+
+#: buddypress/members/single/profile/change-avatar.php:39
+msgid "Delete My Avatar"
+msgstr ""
+
+#: buddypress/members/single/profile/change-avatar.php:78
+msgid "Your avatar will be used on your profile and throughout the site. To change your avatar, please create an account with <a href=\"http://gravatar.com\">Gravatar</a> using the same email address as you used to register with this site."
+msgstr ""
+
+#: buddypress/members/single/profile/edit.php:98
+#: buddypress/members/single/profile/edit.php:111
+msgid "Clear"
+msgstr ""
+
+#: buddypress/members/single/settings.php:33
+#: lib/menus.php:442
+msgid "Export Data"
+msgstr ""
+
+#: buddypress/members/single/settings/delete-account.php:16
+msgid "WARNING: Deleting your account will completely remove ALL content associated with it. There is no way back, please be careful with this option."
+msgstr ""
+
+#: buddypress/members/single/settings/delete-account.php:25
+msgid "I understand the consequences of deleting my account."
+msgstr ""
+
+#: buddypress/members/single/settings/delete-account.php:30
+msgid "Delete My Account"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:19
+#: lib/menus.php:433
+#: lib/menus.php:653
+msgid "Account Settings"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:26
+msgid "Your username cannot be changed."
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:30
+msgid "Account Email Address"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:35
+msgid "Current Password"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:43
+msgid "Required to change email address or password."
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:43
+msgid "Password Lost and Found"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:43
+msgid "Lost your password?"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:47
+msgid "Change Password"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:50
+msgid "Confirm Change Password"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:53
+msgid "Leave blank for no change."
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:61
+#: lib/group-funcs.php:2403
+msgid "Braille Settings"
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:64
+msgid "Enable the Braille toggle to allow you to your private messages in SimBraille, a visual representation of Braille text."
+msgstr ""
+
+#: buddypress/members/single/settings/general.php:69
+msgid "Show Braille toggle for private messages?"
+msgstr ""
+
+#: buddypress/members/single/settings/notifications.php:20
+msgid "Send a notification by email when:"
+msgstr ""
+
+#: buddypress/members/single/sidebar.php:79
+msgid "No recent activity."
+msgstr ""
+
+#: cac-featured-content/cac-featured-resource.php:38
+#: cac-featured-content/cac-featured-resource.php:49
+#: functions.php:293
+msgid "See More"
+msgstr ""
+
+#: cac-featured-content/cac-featured-resource.php:38
+#: cac-featured-content/cac-featured-resource.php:49
+msgid "about this In the Spotlight"
+msgstr ""
+
+#: comments.php:32
+msgid "Trackbacks"
+msgstr ""
+
+#: comments.php:32
+msgid "Trackback"
+msgstr ""
+
+#: event-organiser/calendar.php:29
+#: parts/pages/openlab-calendar.php:1
+#: parts/source/pages/openlab-calendar.php:17
+msgid "Subscribe"
+msgstr ""
+
+#: event-organiser/calendar.php:33
+msgid "Only public events are listed in this iCalendar. Suitable for sharing."
+msgstr ""
+
+#: event-organiser/calendar.php:33
+#: parts/pages/openlab-calendar.php:1
+#: parts/source/pages/openlab-calendar.php:18
+msgid "Download iCalendar file (Public)"
+msgstr ""
+
+#: event-organiser/calendar.php:36
+msgid "Both public and private events are listed in this iCalendar.  Be mindful of who you share this with."
+msgstr ""
+
+#: event-organiser/calendar.php:36
+#: event-organiser/calendar.php:46
+msgid "Download iCalendar file (Private)"
+msgstr ""
+
+#: event-organiser/calendar.php:43
+msgid "Download iCalendar file"
+msgstr ""
+
+#: event-organiser/calendar.php:46
+msgid "This is a private group.  Be mindful of who you share this calendar with."
+msgstr ""
+
+#: event-organiser/event-meta-event-single.php:32
+#: lib/plugin-mods/calendar-control.php:320
+msgid "Event Details"
+msgstr ""
+
+#: event-organiser/event-meta-event-single.php:41
+msgid "This event is running from %1$s until %2$s. It is next occurring on %3$s"
+msgstr ""
+
+#: event-organiser/event-meta-event-single.php:45
+msgid "This event finished on %s"
+msgstr ""
+
+#: event-organiser/event-meta-event-single.php:53
+msgid "Date"
+msgstr ""
+
+#: event-organiser/event-meta-event-single.php:73
+msgid "Upcoming Dates"
+msgstr ""
+
+#: event-organiser/upcoming.php:29
+#: parts/pages/openlab-calendar-upcoming.php:1
+#: parts/sidebar/activity-events-feed.php:1
+#: parts/source/pages/openlab-calendar-upcoming.php:33
+#: parts/source/sidebar/activity-events-feed.php:22
+msgid "No upcoming events found."
+msgstr ""
+
+#: functions.php:26
+#: lib/menus.php:13
+msgid "Help Menu"
+msgstr ""
+
+#: functions.php:27
+#: lib/menus.php:14
+msgid "Help Menu Secondary"
+msgstr ""
+
+#: functions.php:63
+msgid "Your Second Sample Slide"
+msgstr ""
+
+#: functions.php:68
+msgid "Your First Sample Slide"
+msgstr ""
+
+#: functions.php:292
+msgid "Cancel Friendship"
+msgstr ""
+
+#: functions.php:358
+msgid "Home Sidebar"
+msgstr ""
+
+#: functions.php:359
+msgid "The sidebar at the left side of the home page."
+msgstr ""
+
+#: functions.php:367
+msgid "Home Main"
+msgstr ""
+
+#: functions.php:368
+msgid "The main section of the home page. Generally used for group type widgets."
+msgstr ""
+
+#: functions.php:508
+msgid "Powered by:"
+msgstr ""
+
+#: functions.php:519
+msgid "top"
+msgstr ""
+
+#: help-search.php:13
+msgid "Search Help"
+msgstr ""
+
+#: help-search.php:18
+msgid "Results:"
+msgstr ""
+
+#: help-search.php:61
+msgctxt "Group pagination previous text"
+msgid "<i class=\"fa fa-angle-left\"></i>"
+msgstr ""
+
+#: help-search.php:62
+msgctxt "Group pagination next text"
+msgid "<i class=\"fa fa-angle-right\"></i>"
+msgstr ""
+
+#: lib/breadcrumbs.php:18
+msgid "You are here"
+msgstr ""
+
+#: lib/breadcrumbs.php:33
+msgid "View all Help"
+msgstr ""
+
+#: lib/breadcrumbs.php:54
+#: lib/content-processing.php:86
+#: lib/widgets/group-type.php:71
+msgid "&hellip;"
+msgstr ""
+
+#: lib/breadcrumbs.php:167
+msgid "You are here: "
+msgstr ""
+
+#: lib/breadcrumbs.php:168
+#: lib/breadcrumbs.php:169
+#: lib/breadcrumbs.php:170
+#: lib/breadcrumbs.php:171
+#: lib/breadcrumbs.php:173
+#: lib/breadcrumbs.php:174
+msgid "Archives for "
+msgstr ""
+
+#: lib/breadcrumbs.php:172
+msgid "Search for "
+msgstr ""
+
+#: lib/breadcrumbs.php:175
+msgid "Not found: "
+msgstr ""
+
+#: lib/breadcrumbs.php:219
+#: lib/breadcrumbs.php:307
+#: lib/breadcrumbs.php:390
+msgid "View %s"
+msgstr ""
+
+#: lib/breadcrumbs.php:339
+#: lib/breadcrumbs.php:342
+#: lib/breadcrumbs.php:346
+msgid "(Edit)"
+msgstr ""
+
+#: lib/breadcrumbs.php:351
+#: lib/breadcrumbs.php:356
+msgid "View archives for %s"
+msgstr ""
+
+#: lib/breadcrumbs.php:359
+msgid "View archives for %s %s"
+msgstr ""
+
+#: lib/breadcrumbs.php:404
+msgid "View all posts in %s"
+msgstr ""
+
+#: lib/breadcrumbs.php:422
+msgid "View all %s"
+msgstr ""
+
+#: lib/breadcrumbs.php:480
+msgid "View all items in %s"
+msgstr ""
+
+#: lib/buddypress.php:26
+msgid "Comments:"
+msgstr ""
+
+#: lib/buddypress.php:27
+msgid "Posts:"
+msgstr ""
+
+#: lib/buddypress.php:28
+msgid "We found the following feed URLs for your external site, which we'll use to pull posts and comments into your activity stream."
+msgstr ""
+
+#: lib/buddypress.php:29
+msgid "We couldn't find any feed URLs for your external site, which we use to pull posts and comments into your activity stream. If your site has feeds, you may enter the URLs below."
+msgstr ""
+
+#: lib/buddypress.php:30
+msgid "This field cannot be blank."
+msgstr ""
+
+#: lib/buddypress.php:31
+msgid "Please crop your image before continuing."
+msgstr ""
+
+#: lib/buddypress.php:44
+msgid "Complete Sign Up"
+msgstr ""
+
+#: lib/buddypress.php:45
+msgid "&mdash; Checking"
+msgstr ""
+
+#: lib/buddypress.php:46
+msgid "&mdash; OK!"
+msgstr ""
+
+#: lib/buddypress.php:47
+msgid "Enter Email Address to Continue"
+msgstr ""
+
+#: lib/buddypress.php:48
+msgid "&mdash; Invalid code"
+msgstr ""
+
+#: lib/core/page-control.php:65
+msgid "Calendar: Upcoming"
+msgstr ""
+
+#: lib/customizer.php:16
+#: lib/customizer.php:34
+msgid "Color Scheme"
+msgstr ""
+
+#: lib/customizer.php:44
+#: lib/customizer.php:57
+msgid "Logo"
+msgstr ""
+
+#: lib/customizer.php:64
+#: lib/customizer.php:69
+msgid "Select logo"
+msgstr ""
+
+#: lib/customizer.php:65
+msgid "Change logo"
+msgstr ""
+
+#: lib/customizer.php:66
+msgid "Remove"
+msgstr ""
+
+#: lib/customizer.php:67
+msgid "Default"
+msgstr ""
+
+#: lib/customizer.php:68
+msgid "No logo selected"
+msgstr ""
+
+#: lib/customizer.php:70
+msgid "Choose logo"
+msgstr ""
+
+#: lib/customizer.php:85
+msgid "Home Page"
+msgstr ""
+
+#: lib/customizer.php:106
+msgid "Community-wide Footer"
+msgstr ""
+
+#: lib/customizer.php:107
+msgid "This works"
+msgstr ""
+
+#: lib/customizer.php:112
+msgid "Footer - Left"
+msgstr ""
+
+#: lib/customizer.php:114
+msgid "Controls the text on the left-hand side of the community-wide footer."
+msgstr ""
+
+#: lib/customizer.php:129
+#: lib/customizer.php:161
+msgid "Heading"
+msgstr ""
+
+#: lib/customizer.php:144
+msgid "Footer - Middle"
+msgstr ""
+
+#: lib/customizer.php:146
+msgid "Controls the text on the middle of the community-wide footer."
+msgstr ""
+
+#: lib/group-funcs.php:12
+msgid "Group Details"
+msgstr ""
+
+#: lib/group-funcs.php:16
+#: lib/group-funcs.php:457
+#: lib/group-funcs.php:1020
+msgid "Associated Site"
+msgstr ""
+
+#: lib/group-funcs.php:20
+msgid "Invite Members"
+msgstr ""
+
+#: lib/group-funcs.php:66
+#: lib/group-funcs.php:973
+msgid "Privacy Settings"
+msgstr ""
+
+#: lib/group-funcs.php:78
+#: lib/group-funcs.php:510
+#: lib/group-funcs.php:991
+msgid "Public"
+msgstr ""
+
+#: lib/group-funcs.php:85
+#: lib/group-funcs.php:520
+#: lib/group-funcs.php:998
+msgid "Private"
+msgstr ""
+
+#: lib/group-funcs.php:92
+#: lib/group-funcs.php:529
+#: lib/group-funcs.php:1005
+msgid "Hidden"
+msgstr ""
+
+#: lib/group-funcs.php:132
+msgid "Associated Site Details"
+msgstr ""
+
+#: lib/group-funcs.php:152
+msgid "This group is currently associated with the site \"%s\""
+msgstr ""
+
+#: lib/group-funcs.php:153
+msgid "Unlink"
+msgstr ""
+
+#: lib/group-funcs.php:211
+msgid "Set up a site?"
+msgstr ""
+
+#: lib/group-funcs.php:233
+msgid "Name your cloned site:"
+msgstr ""
+
+#: lib/group-funcs.php:239
+#: lib/group-funcs.php:248
+#: lib/group-funcs.php:272
+#: lib/group-funcs.php:281
+msgid "Domain"
+msgstr ""
+
+#: lib/group-funcs.php:266
+msgid "Create a new site:"
+msgstr ""
+
+#: lib/group-funcs.php:311
+msgid "Use an existing site:"
+msgstr ""
+
+#: lib/group-funcs.php:314
+msgid "Choose a site"
+msgstr ""
+
+#: lib/group-funcs.php:316
+msgid "- Choose a site -"
+msgstr ""
+
+#: lib/group-funcs.php:334
+msgid "Use an external site:"
+msgstr ""
+
+#: lib/group-funcs.php:338
+msgid "Input external site URL"
+msgstr ""
+
+#: lib/group-funcs.php:340
+msgctxt "External site RSS feed check button"
+msgid "Check"
+msgstr ""
+
+#: lib/group-funcs.php:340
+msgid "Check external site for Post and Comment feeds"
+msgstr ""
+
+#: lib/group-funcs.php:379
+#: lib/group-funcs.php:447
+#: lib/group-funcs.php:460
+msgid "Administrator"
+msgstr ""
+
+#: lib/group-funcs.php:380
+#: lib/group-funcs.php:461
+msgid "Editor"
+msgstr ""
+
+#: lib/group-funcs.php:382
+#: lib/group-funcs.php:463
+msgid "Contributor"
+msgstr ""
+
+#: lib/group-funcs.php:383
+#: lib/group-funcs.php:464
+msgid "Subscriber"
+msgstr ""
+
+#: lib/group-funcs.php:404
+msgid "Member Role Settings"
+msgstr ""
+
+#: lib/group-funcs.php:407
+msgid "These settings control the default member roles on your associated site when members join the group. You may also adjust individual member roles in Membership settings and on the site Dashboard."
+msgstr ""
+
+#: lib/group-funcs.php:413
+msgid "Group members have the following role on the associated site:"
+msgstr ""
+
+#: lib/group-funcs.php:422
+msgid "Group moderators have the following role on the associated site:"
+msgstr ""
+
+#: lib/group-funcs.php:431
+msgid "Group administrators have the following role on the associated site:"
+msgstr ""
+
+#: lib/group-funcs.php:444
+#: lib/group-funcs.php:457
+msgid "Member Role Definitions: %s"
+msgstr ""
+
+#: lib/group-funcs.php:447
+msgid "Someone who can change group settings (such as changing privacy settings); edit, close, and delete discussion forum topics; and edit and delete docs. They can also change the avatar, manage membership, and delete the group."
+msgstr ""
+
+#: lib/group-funcs.php:448
+msgid "Moderator"
+msgstr ""
+
+#: lib/group-funcs.php:448
+msgid "Someone who can edit edit, close, and delete discussion forum topics, and edit and delete docs."
+msgstr ""
+
+#: lib/group-funcs.php:449
+#: lib/group-funcs.php:1173
+msgid "Member"
+msgstr ""
+
+#: lib/group-funcs.php:449
+msgid "Someone who can post in discussion forums, edit docs (depending on settings determined by the admin), and upload files."
+msgstr ""
+
+#: lib/group-funcs.php:460
+msgid "Someone who can control every aspect of a site, from managing content and comments, to choosing site themes to activating widgets and plugins.  In most cases, you should not make another site user an Administrator unless you want them to have equal control over your site content and functions."
+msgstr ""
+
+#: lib/group-funcs.php:461
+msgid "Someone who can write and publish posts, as well as manage the posts of other users.  Editors can also make changes to pages, but cannot change the theme, menu, widgets, plugins, or edit other user roles."
+msgstr ""
+
+#: lib/group-funcs.php:462
+msgid "Someone who can publish and edit their own content, but cannot change or delete anything that anyone else has created on the site.  In most cases, if you are adding additional users to your site, making them site Authors is the best choice."
+msgstr ""
+
+#: lib/group-funcs.php:463
+msgid "Someone who can write and edit their own posts, but can’t publish them.  They can save them as drafts for an Editor or Administrator to publish."
+msgstr ""
+
+#: lib/group-funcs.php:464
+msgid "Someone who can only log in and manage their profile, but they can’t post or change anything on the site."
+msgstr ""
+
+#: lib/group-funcs.php:504
+msgid "Associated Site Privacy Settings"
+msgstr ""
+
+#: lib/group-funcs.php:506
+#: lib/group-funcs.php:1022
+msgid "These settings affect how others view your associated site."
+msgstr ""
+
+#: lib/group-funcs.php:513
+msgid "Allow search engines to index this site. The site will show up in web search results."
+msgstr ""
+
+#: lib/group-funcs.php:515
+msgid "Ask search engines not to index this site. The site should not show up in web search results."
+msgstr ""
+
+#: lib/group-funcs.php:516
+msgid "Note: This option will NOT block access to the site. It is up to search engines to honor your request."
+msgstr ""
+
+#: lib/group-funcs.php:523
+msgid "I would like the site to be visible only to members of this community."
+msgstr ""
+
+#: lib/group-funcs.php:525
+msgid "I would like the site to be visible to community members with a role on the associated site."
+msgstr ""
+
+#: lib/group-funcs.php:532
+msgid "I would like my site to be visible only to those members with an administrator role on the associated site."
+msgstr ""
+
+#: lib/group-funcs.php:565
+msgid "URL (required)"
+msgstr ""
+
+#: lib/group-funcs.php:582
+msgid "URLs must meet the following criteria:"
+msgstr ""
+
+#: lib/group-funcs.php:584
+msgid "Can contain only lowercase characters, numbers, hyphens, and underscores."
+msgstr ""
+
+#: lib/group-funcs.php:585
+msgid "Cannot begin or end with a non-alphanumeric character."
+msgstr ""
+
+#: lib/group-funcs.php:586
+msgid "Must be at least 3 characters long."
+msgstr ""
+
+#: lib/group-funcs.php:591
+msgid "That URL is already taken."
+msgstr ""
+
+#: lib/group-funcs.php:662
+msgid "The maximum upload size is %s."
+msgstr ""
+
+#: lib/group-funcs.php:978
+#: lib/group-funcs.php:980
+msgid "These settings affect how others view your group's Profile."
+msgstr ""
+
+#: lib/group-funcs.php:978
+msgid "You may change these settings later in the group's Profile Settings."
+msgstr ""
+
+#: lib/group-funcs.php:993
+msgid "Profile and related content and activity will be visible to the public."
+msgstr ""
+
+#: lib/group-funcs.php:994
+#: lib/group-funcs.php:1001
+msgid "Will be listed in the \"%s\" directory, in search results, and may be displayed on the home page."
+msgstr ""
+
+#: lib/group-funcs.php:995
+msgid "Any site member may join this group."
+msgstr ""
+
+#: lib/group-funcs.php:1000
+msgid "Profile and related content and activity will only be visible to members of the group."
+msgstr ""
+
+#: lib/group-funcs.php:1002
+msgid "Only site members who request membership and are accepted may join this group."
+msgstr ""
+
+#: lib/group-funcs.php:1007
+msgid "Profile, related content, and activity will only be visible only to members of the group."
+msgstr ""
+
+#: lib/group-funcs.php:1008
+msgid "Will NOT be listed in the \"%s\" directory, in search results, or on the home page."
+msgstr ""
+
+#: lib/group-funcs.php:1009
+msgid "Only site members who are invited may join this group."
+msgstr ""
+
+#: lib/group-funcs.php:1075
+#: lib/member-funcs.php:174
+msgctxt "Group pagination previous text"
+msgid "<i class=\"fa fa-angle-left\" aria-hidden=\"true\"></i><span class=\"sr-only\">Previous</span>"
+msgstr ""
+
+#: lib/group-funcs.php:1076
+#: lib/member-funcs.php:175
+msgctxt "Group pagination next text"
+msgid "<i class=\"fa fa-angle-right\" aria-hidden=\"true\"></i><span class=\"sr-only\">Next</span>"
+msgstr ""
+
+#: lib/group-funcs.php:1098
+msgctxt "Forum pagination previous text"
+msgid "<i class=\"fa fa-angle-left\" aria-hidden=\"true\"></i>"
+msgstr ""
+
+#: lib/group-funcs.php:1099
+msgctxt "Forum pagination next text"
+msgid "<i class=\"fa fa-angle-right\" aria-hidden=\"true\"></i>"
+msgstr ""
+
+#: lib/group-funcs.php:1156
+msgid "%1$s to %2$s (of %3$s total)"
+msgstr ""
+
+#: lib/group-funcs.php:1169
+msgid "Admin"
+msgstr ""
+
+#: lib/group-funcs.php:1171
+msgid "Mod"
+msgstr ""
+
+#: lib/group-funcs.php:1195
+#: lib/group-funcs.php:1201
+#: lib/menus.php:1046
+msgid "active %s"
+msgstr ""
+
+#: lib/group-funcs.php:1286
+msgid "Recent Discussions"
+msgstr ""
+
+#: lib/group-funcs.php:1322
+msgid "Sorry, there were no discussion topics found."
+msgstr ""
+
+#: lib/group-funcs.php:1334
+msgid "Recent Docs"
+msgstr ""
+
+#: lib/group-funcs.php:1358
+msgid "No Recent Docs"
+msgstr ""
+
+#: lib/group-funcs.php:1472
+#: lib/menus.php:1010
+#: lib/menus.php:1028
+msgctxt "Group admin nav item"
+msgid "Site"
+msgstr ""
+
+#: lib/group-funcs.php:1503
+msgid "Site settings successfully saved."
+msgstr ""
+
+#: lib/group-funcs.php:1565
+msgid "Leave"
+msgstr ""
+
+#: lib/group-funcs.php:1570
+msgid "Join"
+msgstr ""
+
+#: lib/group-funcs.php:1608
+msgid "Email Subscription Defaults"
+msgstr ""
+
+#: lib/group-funcs.php:1609
+msgid "When new users join this group, their default email notification settings will be:"
+msgstr ""
+
+#: lib/group-funcs.php:1612
+msgid "No Email ( users will read this group on the web - good for any group - the default )"
+msgstr ""
+
+#: lib/group-funcs.php:1614
+msgid "Weekly Summary Email ( the week's topics - good for large groups )"
+msgstr ""
+
+#: lib/group-funcs.php:1616
+msgid "Daily Digest Email ( all daily activity bundles in one email - good for medium-size groups )"
+msgstr ""
+
+#: lib/group-funcs.php:1618
+msgid "New Topics Email ( new topics are sent as they arrive, but not replies - good for small groups )"
+msgstr ""
+
+#: lib/group-funcs.php:1620
+msgid "All Email ( send emails about everything - recommended only for working groups )"
+msgstr ""
+
+#: lib/group-funcs.php:1881
+msgid "Recent Posts"
+msgstr ""
+
+#: lib/group-funcs.php:1893
+#: lib/group-funcs.php:1916
+msgid "Feed updates automatically every 10 minutes"
+msgstr ""
+
+#: lib/group-funcs.php:1893
+#: lib/group-funcs.php:1916
+msgid "Refresh now"
+msgstr ""
+
+#: lib/group-funcs.php:1902
+msgid "Recent Comments"
+msgstr ""
+
+#: lib/group-funcs.php:1912
+msgid "No Comments Found"
+msgstr ""
+
+#: lib/group-funcs.php:2038
+#: lib/group-funcs.php:2060
+#: lib/menus.php:737
+msgid "Site Dashboard"
+msgstr ""
+
+#: lib/group-funcs.php:2406
+msgid "Adds a \"Braille\" toggle to each discussion thread item, enabling members to read discussion content in SimBraille, a visual representation of Braille text."
+msgstr ""
+
+#: lib/group-funcs.php:2409
+msgid "Enable Braille toggle for discussion content?"
+msgstr ""
+
+#: lib/group-funcs.php:2452
+msgid "Additional Description/HTML"
+msgstr ""
+
+#: lib/group-funcs.php:2548
+msgid "Spring"
+msgstr ""
+
+#: lib/group-funcs.php:2551
+msgid "Fall"
+msgstr ""
+
+#: lib/group-funcs.php:2579
+msgid "Academic term for this course"
+msgstr ""
+
+#: lib/group-funcs.php:2647
+msgid "You successfully left the group."
+msgstr ""
+
+#: lib/group-funcs.php:2648
+msgid "You successfully left."
+msgstr ""
+
+#: lib/group-funcs.php:2651
+msgid "You joined the group!"
+msgstr ""
+
+#: lib/group-funcs.php:2652
+msgid "You joined!"
+msgstr ""
+
+#: lib/group-funcs.php:2655
+msgid "Your membership request was sent to the group administrator successfully. You will be notified when the group administrator responds to your request."
+msgstr ""
+
+#: lib/group-funcs.php:2656
+msgid "Your membership request was sent successfully. You will be notified when your request has been addressed."
+msgstr ""
+
+#: lib/group-funcs.php:2659
+msgid "Group created successfully."
+msgstr ""
+
+#: lib/group-funcs.php:2660
+msgid "Created successfully."
+msgstr ""
+
+#: lib/group-funcs.php:2782
+msgid "There was a problem deleting the avatar. Please try again."
+msgstr ""
+
+#: lib/group-funcs.php:2786
+msgid "The avatar was deleted successfully."
+msgstr ""
+
+#: lib/help-funcs.php:85
+msgid "Print this page"
+msgstr ""
+
+#: lib/help-funcs.php:124
+msgid "Do you have a question? You're in the right place!"
+msgstr ""
+
+#: lib/help-funcs.php:186
+msgid "Tag Archive for: %s"
+msgstr ""
+
+#: lib/media-funcs.php:35
+msgid "You haven't added any slides yet!"
+msgstr ""
+
+#: lib/member-funcs.php:89
+#: lib/widgets/new-members.php:64
+#: lib/widgets/whos-online.php:44
+msgid "Member avatar"
+msgstr ""
+
+#: lib/member-funcs.php:157
+msgid "There are no people to display."
+msgstr ""
+
+#: lib/member-funcs.php:198
+msgid "%1$s to %2$s (of %3$s members)"
+msgstr ""
+
+#: lib/member-funcs.php:434
+msgid "None found."
+msgstr ""
+
+#: lib/member-funcs.php:524
+msgctxt "Group pagination previous text"
+msgid "<i class=\"fa fa-angle-left\" aria-hidden=\"true\"></i>"
+msgstr ""
+
+#: lib/member-funcs.php:525
+msgctxt "Group pagination next text"
+msgid "<i class=\"fa fa-angle-right\" aria-hidden=\"true\"></i>"
+msgstr ""
+
+#. translators: 1. count span
+#: lib/menus.php:126
+msgid "Files %1$s"
+msgstr ""
+
+#. translators: 1. count span
+#: lib/menus.php:150
+msgid "Docs %1$s"
+msgstr ""
+
+#: lib/menus.php:346
+msgid "My Invitations"
+msgstr ""
+
+#: lib/menus.php:362
+msgid "My Messages"
+msgstr ""
+
+#: lib/menus.php:378
+msgid "My Settings"
+msgstr ""
+
+#: lib/menus.php:434
+msgid "Email Notifications"
+msgstr ""
+
+#: lib/menus.php:447
+msgid "Delete Account"
+msgstr ""
+
+#: lib/menus.php:502
+msgid "Step Two: Associated Site Creation"
+msgstr ""
+
+#: lib/menus.php:505
+msgid "Step Three: %s"
+msgstr ""
+
+#: lib/menus.php:509
+msgid "Step One: %s"
+msgstr ""
+
+#: lib/menus.php:551
+msgid "Requests Received"
+msgstr ""
+
+#: lib/menus.php:580
+msgid "Inbox"
+msgstr ""
+
+#: lib/menus.php:581
+#: lib/plugin-mods/invite-funcs.php:292
+msgid "Sent"
+msgstr ""
+
+#: lib/menus.php:582
+msgid "Compose"
+msgstr ""
+
+#: lib/menus.php:595
+msgid "Invitations Received"
+msgstr ""
+
+#: lib/menus.php:596
+#: lib/menus.php:659
+#: lib/menus.php:1080
+#: lib/plugin-mods/invite-funcs.php:43
+#: lib/plugin-mods/invite-funcs.php:100
+msgid "Invite New Members"
+msgstr ""
+
+#: lib/menus.php:597
+#: lib/menus.php:646
+msgid "Sent Invitations"
+msgstr ""
+
+#: lib/menus.php:719
+msgid "Profile"
+msgstr ""
+
+#: lib/menus.php:733
+msgid "Site"
+msgstr ""
+
+#: lib/menus.php:1014
+msgid "Delete Portfolio"
+msgstr ""
+
+#: lib/menus.php:1038
+msgid "Clone"
+msgstr ""
+
+#: lib/menus.php:1070
+#: lib/menus.php:1076
+msgid "Membership"
+msgstr ""
+
+#: lib/menus.php:1073
+msgid "Member Requests"
+msgstr ""
+
+#: lib/menus.php:1084
+msgid "Email Members"
+msgstr ""
+
+#: lib/menus.php:1088
+msgid "Your Email Options"
+msgstr ""
+
+#: lib/menus.php:1111
+msgid "View Docs"
+msgstr ""
+
+#: lib/menus.php:1113
+msgid "New Doc"
+msgstr ""
+
+#: lib/nav.php:120
+msgctxt "Group pagination previous text"
+msgid "&larr;"
+msgstr ""
+
+#: lib/nav.php:121
+msgctxt "Group pagination next text"
+msgid "&rarr;"
+msgstr ""
+
+#: lib/plugin-hooks.php:155
+msgid "<i class=\"fa fa-angle-left\"></i>"
+msgstr ""
+
+#: lib/plugin-hooks.php:156
+msgid "<i class=\"fa fa-angle-right\"></i>"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:306
+msgid "<strong>Author:</strong> %s"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:375
+msgid "This is a recurring event. Check to edit this event and its recurrences"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:394
+msgid "Enter date in %s format"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:395
+msgid "Enter time in 24-hour hh colon mm format"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:395
+msgid "Enter time in 12-hour hh colon mm am or pm format"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:399
+msgid "none"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:400
+msgid "daily"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:401
+msgid "weekly"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:402
+msgid "monthly"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:403
+msgid "yearly"
+msgstr ""
+
+#: lib/plugin-mods/calendar-control.php:404
+msgid "custom"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:30
+msgid "Email Subscription Options"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:36
+msgid "How do you want to be notified about activity in \"%s\"?"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:40
+msgid "No Email"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:41
+msgid "I will read all content on the web"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:45
+msgid "Weekly Summary Email"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:46
+msgid "Get a summary of new topics each week"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:50
+msgid "Daily Digest Email"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:51
+msgid "Get all the day's activity bundled into a single email"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:56
+msgid "New Topics Email"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:57
+msgid "Send new topics as they arrive (but don't send replies)"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:62
+msgid "All Email"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:63
+msgid "Send all activity as it arrives"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:68
+msgid "Save Settings"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:72
+msgid "Note: Normally, you receive email notifications for topics you start or comment on. This can be changed at"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:72
+msgid "email notifications"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:88
+msgid "Individual Group Email Settings"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:96
+msgid "To change the email notification settings for { your Courses, Projects, Clubs and Portfolio:"
+msgstr ""
+
+#: lib/plugin-mods/email-funcs.php:104
+msgid "Or set all your group's email options to No Email"
+msgstr ""
+
+#: lib/plugin-mods/files-funcs.php:47
+msgid "Viewing item %1$s to %1$s (of %1$s items)"
+msgstr ""
+
+#: lib/plugin-mods/files-funcs.php:101
+msgid "Document successfully uploaded"
+msgstr ""
+
+#: lib/plugin-mods/files-funcs.php:102
+msgid "File successfully uploaded"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:32
+msgid "It looks like you&#8217;ve already accepted your invitation to join the site."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:45
+msgid "You have sent the maximum allowed number of invitations."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:95
+msgid "Invite friends to join %s by following these steps:"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:107
+msgid "Some of your invitations were not sent. Please see the errors below and resubmit the failed invitations."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:132
+msgid "The site administrator has limited each user to %1$d invitations. You have %2$d invitations remaining."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:145
+msgid "Enter email addresses below, one per line."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:146
+msgid "You can only invite people whose email addresses end in one of the following domains:"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:150
+msgid "You can invite a maximum of %s people at a time."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:162
+msgid "(optional) Customize the subject line of the invitation email."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:165
+msgid "Subject: <span class=\"disabled-subject\">Subject line is fixed</span>"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:174
+msgid "(optional) Customize the text of the invitation."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:175
+msgid "The message will also contain a custom footer containing links to accept the invitation or opt out of further email invitations from this site."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:178
+msgid "Message:"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:189
+msgid "(optional) Select some groups. Invitees will receive invitations to these groups when they join the site."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:278
+msgid "Sent Invites"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:281
+msgid "You have sent invitations to the following people."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:284
+msgid ""
+"This table displays a list of all your sent invites.\n"
+"\t\t\tInvites that have been accepted are highlighted in the listings.\n"
+"\t\t\tYou may clear any individual invites, all accepted invites or all of the invites from the list."
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:290
+msgid "Invited email address"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:291
+msgid "Group invitations"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:293
+msgid "Accepted"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:301
+msgid "Clear all accepted invites from the list"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:301
+msgid "Clear all accepted invitations"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:302
+msgid "Clear all your listed invites"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:302
+msgid "Clear all invitations"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:328
+msgid "Clear this invitation"
+msgstr ""
+
+#: lib/plugin-mods/invite-funcs.php:382
+msgid "You haven't sent any email invitations yet."
+msgstr ""
+
+#: lib/post-types.php:9
+msgctxt "taxonomy general name"
+msgid "Help Categories"
+msgstr ""
+
+#: lib/post-types.php:10
+msgctxt "taxonomy singular name"
+msgid "Help Category"
+msgstr ""
+
+#: lib/post-types.php:11
+msgid "Search Help Categories"
+msgstr ""
+
+#: lib/post-types.php:12
+msgid "All Help Categories"
+msgstr ""
+
+#: lib/post-types.php:13
+msgid "Parent Help Category"
+msgstr ""
+
+#: lib/post-types.php:14
+msgid "Parent Help Category:"
+msgstr ""
+
+#: lib/post-types.php:15
+msgid "Edit Help Category"
+msgstr ""
+
+#: lib/post-types.php:16
+msgid "Update Help Category"
+msgstr ""
+
+#: lib/post-types.php:17
+msgid "Add New Help Category"
+msgstr ""
+
+#: lib/post-types.php:18
+msgid "New Help Category Name"
+msgstr ""
+
+#: lib/post-types.php:19
+msgid "Help Category"
+msgstr ""
+
+#: lib/post-types.php:31
+msgctxt "taxonomy general name"
+msgid "Help Tags"
+msgstr ""
+
+#: lib/post-types.php:32
+msgctxt "taxonomy singular name"
+msgid "Help Tag"
+msgstr ""
+
+#: lib/post-types.php:33
+msgid "Search Help Tags"
+msgstr ""
+
+#: lib/post-types.php:34
+msgid "Popular Help Tags"
+msgstr ""
+
+#: lib/post-types.php:35
+msgid "All Help Tags"
+msgstr ""
+
+#: lib/post-types.php:38
+msgid "Edit Help Tag"
+msgstr ""
+
+#: lib/post-types.php:39
+msgid "Update Help Tag"
+msgstr ""
+
+#: lib/post-types.php:40
+msgid "Add New Help Tag"
+msgstr ""
+
+#: lib/post-types.php:41
+msgid "New Help Tag Name"
+msgstr ""
+
+#: lib/post-types.php:42
+msgid "Separate help tags with commas"
+msgstr ""
+
+#: lib/post-types.php:43
+msgid "Add or remove help tags"
+msgstr ""
+
+#: lib/post-types.php:44
+msgid "Choose from the most used help tags"
+msgstr ""
+
+#: lib/post-types.php:45
+msgid "Help Tags"
+msgstr ""
+
+#: lib/post-types.php:64
+#: lib/post-types.php:65
+#: lib/post-types.php:75
+msgctxt "help"
+msgid "Help"
+msgstr ""
+
+#: lib/post-types.php:66
+msgctxt "help"
+msgid "Add New"
+msgstr ""
+
+#: lib/post-types.php:67
+msgctxt "help"
+msgid "Add New Help"
+msgstr ""
+
+#: lib/post-types.php:68
+msgctxt "help"
+msgid "Edit Help"
+msgstr ""
+
+#: lib/post-types.php:69
+msgctxt "help"
+msgid "New Help"
+msgstr ""
+
+#: lib/post-types.php:70
+msgctxt "help"
+msgid "View Help"
+msgstr ""
+
+#: lib/post-types.php:71
+msgctxt "help"
+msgid "Search Help"
+msgstr ""
+
+#: lib/post-types.php:72
+msgctxt "help"
+msgid "No help found"
+msgstr ""
+
+#: lib/post-types.php:73
+msgctxt "help"
+msgid "No help found in Trash"
+msgstr ""
+
+#: lib/post-types.php:74
+msgctxt "help"
+msgid "Parent Help:"
+msgstr ""
+
+#: lib/post-types.php:156
+#: lib/post-types.php:157
+#: lib/post-types.php:167
+msgctxt "help glossary"
+msgid "Help Glossary"
+msgstr ""
+
+#: lib/post-types.php:158
+msgctxt "help glossary"
+msgid "Add New"
+msgstr ""
+
+#: lib/post-types.php:159
+msgctxt "help glossary"
+msgid "Add New Help Glossary"
+msgstr ""
+
+#: lib/post-types.php:160
+msgctxt "help glossary"
+msgid "Edit Help Glossary"
+msgstr ""
+
+#: lib/post-types.php:161
+msgctxt "help glossary"
+msgid "New Help Glossary"
+msgstr ""
+
+#: lib/post-types.php:162
+msgctxt "help glossary"
+msgid "View Help Glossary"
+msgstr ""
+
+#: lib/post-types.php:163
+msgctxt "help glossary"
+msgid "Search Help Glossary"
+msgstr ""
+
+#: lib/post-types.php:164
+msgctxt "help glossary"
+msgid "No help glossary found"
+msgstr ""
+
+#: lib/post-types.php:165
+msgctxt "help glossary"
+msgid "No help glossary found in Trash"
+msgstr ""
+
+#: lib/post-types.php:166
+msgctxt "help glossary"
+msgid "Parent Help Glossary:"
+msgstr ""
+
+#: lib/post-types.php:230
+#: lib/post-types.php:241
+msgctxt "slider"
+msgid "Sliders"
+msgstr ""
+
+#: lib/post-types.php:231
+msgctxt "slider"
+msgid "Slider"
+msgstr ""
+
+#: lib/post-types.php:232
+msgctxt "slider"
+msgid "Add New"
+msgstr ""
+
+#: lib/post-types.php:233
+msgctxt "slider"
+msgid "Add New Slider"
+msgstr ""
+
+#: lib/post-types.php:234
+msgctxt "slider"
+msgid "Edit Slider"
+msgstr ""
+
+#: lib/post-types.php:235
+msgctxt "slider"
+msgid "New Slider"
+msgstr ""
+
+#: lib/post-types.php:236
+msgctxt "slider"
+msgid "View Slider"
+msgstr ""
+
+#: lib/post-types.php:237
+msgctxt "slider"
+msgid "Search Sliders"
+msgstr ""
+
+#: lib/post-types.php:238
+msgctxt "slider"
+msgid "No sliders found"
+msgstr ""
+
+#: lib/post-types.php:239
+msgctxt "slider"
+msgid "No sliders found in Trash"
+msgstr ""
+
+#: lib/post-types.php:240
+msgctxt "slider"
+msgid "Parent Slider:"
+msgstr ""
+
+#: lib/widgets/group-type.php:14
+msgid "Group Type"
+msgstr ""
+
+#: lib/widgets/group-type.php:16
+msgid "Displays recently active groups of a specific Group Type"
+msgstr ""
+
+#: lib/widgets/group-type.php:81
+msgid "Nothing to show."
+msgstr ""
+
+#: lib/widgets/group-type.php:101
+msgid "Group Type:"
+msgstr ""
+
+#: lib/widgets/group-type.php:103
+msgid "- Select Group Type -"
+msgstr ""
+
+#: lib/widgets/new-members.php:23
+msgid "Newest members of the site."
+msgstr ""
+
+#: lib/widgets/new-members.php:48
+msgid "Previous New Members"
+msgstr ""
+
+#: lib/widgets/new-members.php:50
+msgid "Next New Members"
+msgstr ""
+
+#: lib/widgets/new-members.php:52
+msgid "Browse through and say \"Hello!\" to the newest members of the site."
+msgstr ""
+
+#: lib/widgets/whats-happening.php:23
+msgid "A list of recent activity items from around the site."
+msgstr ""
+
+#: lib/widgets/whats-happening.php:25
+msgid "What's Happening"
+msgstr ""
+
+#: lib/widgets/whats-happening.php:89
+msgid "No recent activity"
+msgstr ""
+
+#: lib/widgets/whos-online.php:23
+msgid "Avatars of recently active members."
+msgstr ""
+
+#: parts/forms/group-categories.php:1
+#: parts/source/forms/group-categories.php:6
+msgid "Please select from the following categories."
+msgstr ""
+
+#: parts/home/login.php:1
+#: parts/source/home/login.php:47
+msgid "Avatar for %s"
+msgstr ""
+
+#. translators: logged-in user display name
+#: parts/home/login.php:1
+#: parts/source/home/login.php:56
+msgid "Not %s?"
+msgstr ""
+
+#: parts/home/login.php:1
+#: parts/source/home/login.php:69
+msgid "Need Help?"
+msgstr ""
+
+#: parts/home/login.php:1
+#: parts/source/home/login.php:81
+msgid "Sign up"
+msgstr ""
+
+#: parts/home/login.php:1
+#: parts/source/home/login.php:82
+msgid "Need an account?"
+msgstr ""
+
+#: parts/home/login.php:1
+#: parts/source/home/login.php:83
+msgid "Sign Up to become a member!"
+msgstr ""
+
+#: parts/home/login.php:1
+#: parts/source/home/login.php:106
+msgid "Keep me logged in"
+msgstr ""
+
+#: parts/pages/openlab-calendar-upcoming.php:1
+#: parts/source/pages/openlab-calendar-upcoming.php:12
+msgid "Upcoming Events"
+msgstr ""
+
+#: parts/pages/openlab-calendar.php:1
+#: parts/source/pages/openlab-calendar.php:4
+#: single-event.php:41
+msgid "Calendar:"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:7
+msgid "Start Date/Time:"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:12
+msgid "Start Date"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:16
+msgid "Start Time"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:30
+msgid "End Date/Time:"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:35
+msgid "End Date"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:39
+msgid "End Time"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:51
+msgid "All day"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:60
+msgid "Recurrence:"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:75
+msgid "Repeat every"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:76
+msgid "Recurrence frequency"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:83
+msgid "Repeat on days of week:"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:84
+msgid "on"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:105
+msgid "Select whether to repeat monthly by date or day:"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:109
+msgid "date of month"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:113
+msgid "day of week"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:119
+msgid "until"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:120
+msgid "Repeat this event until:"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:131
+msgid "Include/Exclude occurrences:"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:134
+msgid "Show dates"
+msgstr ""
+
+#: parts/plugin-mods/calendar-custom-event-meta-box.php:1
+#: parts/source/plugin-mods/calendar-custom-event-meta-box.php:151
+msgid "Venue Name"
+msgstr ""
+
+#: sidebar-group-archive.php:92
+msgid "Narrow down your search using the filters or search box below."
+msgstr ""
+
+#: sidebar-group-archive.php:105
+msgid "Select: %s"
+msgstr ""
+
+#: sidebar-group-archive.php:124
+msgid "Select: Category"
+msgstr ""
+
+#: sidebar-group-archive.php:141
+msgid "Select: Term"
+msgstr ""
+
+#: sidebar-group-archive.php:154
+msgid "Select: User Type"
+msgstr ""
+
+#: sidebar-group-archive.php:156
+msgid "User Type"
+msgstr ""
+
+#: sidebar-group-archive.php:165
+msgid "Select: Order"
+msgstr ""
+
+#: sidebar-group-archive.php:182
+msgid "Enter keyword"
+msgstr ""
+
+#: single-event.php:35
+msgid "OpenLab Calendar: Event"
+msgstr ""
+
+#. translators
+#: single.php:23
+msgid "Posted on %1$s by %2$s"
 msgstr ""


### PR DESCRIPTION
See #114, #148.

In #148 we discussed the possibility of using a tool to combine all strings from across our subpackages into a single .php file or .pot file, to enable compatibility with wordpress.org translation tools. I spent a little time writing a proof-of-concept for it. It's pretty straightforward:

1. Prepare a list of plugins and themes whose strings should be collected
2. Loop through each, and use `wp i18n make-pot` to make package-specific .pot files. commons-in-a-box comes first, so that the readme.txt info takes precedence in the next step
3. Run `wp i18n make-pot` one more time, with the `--merge` argument that puts all the previous .pot files together into one.

The nice thing here is that we can decide, if we wish, to add other non-wordpress.org packages, like perhaps `cbox-theme`.

One prerequisite, though, is that a single .pot file can only serve a single text domain. So any package included in the .pot would have to use `cbox` (or ideally `commons-in-a-box`). I didn't make that change for this proof-of-concept.

I'm pinging @r-a-y because we've thought about this together in the past, and @Mamaduka because perhaps you'll have some brilliant ideas that we haven't thought of :-D