### PR TITLE
Adds POC for Upgrades API

### DIFF
--- a/admin/admin-loader.php
+++ b/admin/admin-loader.php
@@ -87,12 +87,6 @@ class CBox_Admin {
 			return;
 		}
 
-		// See if we have items to upgrade.
-		$items = CBOX\Upgrades\Upgrade_Registry::get_instance()->get_all_registered();
-		if ( empty( $items ) ) {
-			return;
-		}
-
 		require CBOX_PLUGIN_DIR . 'admin/upgrades/pages.php';
 	}
 

--- a/admin/admin-loader.php
+++ b/admin/admin-loader.php
@@ -1119,21 +1119,18 @@ class CBox_Admin {
 				$notice_text = __( "Let's get started!", 'commons-in-a-box' );
 				$button_link = cbox_admin_prop( 'url', 'admin.php?page=cbox' );
 				$button_text = __( 'Click here to get set up', 'commons-in-a-box' );
-				$disable_btn = 'cbox';
 				break;
 
 			case 'theme-update' :
 				$notice_text = sprintf( __( 'The %1$s theme needs an update.', 'commons-in-a-box' ), esc_attr( cbox_get_theme_prop( 'name' ) ) );
 				$button_link = wp_nonce_url( cbox_admin_prop( 'url', 'admin.php?page=cbox&amp;cbox-action=upgrade-theme&amp;cbox-themes=' . esc_attr( cbox_get_theme_prop( 'directory_name' ) ) ), 'cbox_upgrade_theme' );
 				$button_text = __( 'Update the theme &rarr;', 'commons-in-a-box' );
-				$disable_btn = 'cbox';
 				break;
 
 			case 'recommended-plugins' :
 				$notice_text = __( 'You only have one last thing to do. We promise!', 'commons-in-a-box' );
 				$button_link = cbox_admin_prop( 'url', 'admin.php?page=cbox' );
 				$button_text = __( 'Click here to finish up!', 'commons-in-a-box' );
-				$disable_btn = 'cbox';
 				break;
 
 			case 'upgrades-available' :
@@ -1155,15 +1152,13 @@ class CBox_Admin {
 			} else {
 				$notice_text = __( 'Installing plugins...', 'commons-in-a-box' );
 			}
-
-			$disable_btn = 'cbox';
 		}
 	?>
 
 		<div id="cbox-nag" class="updated">
 			<strong><?php _e( "Commons In A Box is almost ready!", 'commons-in-a-box' ); ?></strong> <?php echo $notice_text; ?>
 
-			<?php if ( empty( $_REQUEST['page'] ) || ( ! empty( $_REQUEST['page'] ) && $_REQUEST['page'] != $disable_btn ) ) : ?>
+			<?php if ( empty( $_REQUEST['page'] ) || ( ! empty( $_REQUEST['page'] ) && 'cbox' !== $_REQUEST['page'] ) ) : ?>
 				<p><a class="callout" href="<?php echo $button_link; ?>"><?php echo $button_text; ?></a></p>
 			<?php endif; ?>
 

--- a/admin/admin-loader.php
+++ b/admin/admin-loader.php
@@ -34,6 +34,8 @@ class CBox_Admin {
 	 */
 	private function includes() {
 		require( CBOX_PLUGIN_DIR . 'admin/functions.php' );
+		require( CBOX_PLUGIN_DIR . 'admin/upgrades/list-table.php' );
+		require( CBOX_PLUGIN_DIR . 'admin/upgrades/pages.php' );
 
 		/**
 		 * Hook to declare when the CBOX admin area is loaded at its earliest.
@@ -368,7 +370,7 @@ class CBox_Admin {
 				cbox_get_template_part( 'package-details', $package );
 			?>
 
-				<form method="post" action="<?php echo self_admin_url( 'admin.php?page=cbox' ); ?>" style="margin-top:2em; text-align:right;, ">
+				<form method="post" action="<?php echo self_admin_url( 'admin.php?page=cbox' ); ?>" style="margin-top:2em; text-align:right;">
 					<?php wp_nonce_field( 'cbox_select_package' ); ?>
 
 					<input type="hidden" name="cbox-package" value="<?php echo $package; ?>" />

--- a/admin/admin-loader.php
+++ b/admin/admin-loader.php
@@ -34,8 +34,6 @@ class CBox_Admin {
 	 */
 	private function includes() {
 		require( CBOX_PLUGIN_DIR . 'admin/functions.php' );
-		require( CBOX_PLUGIN_DIR . 'admin/upgrades/list-table.php' );
-		require( CBOX_PLUGIN_DIR . 'admin/upgrades/pages.php' );
 
 		/**
 		 * Hook to declare when the CBOX admin area is loaded at its earliest.
@@ -73,6 +71,29 @@ class CBox_Admin {
 
 		// after installing a theme, do something
 		add_action( 'admin_init',                                                   array( $this, 'theme_activation_hook' ) );
+
+		// Upgrader page.
+		add_action( 'cbox_admin_menu',                                              array( $this, 'upgrader' ), 0 );
+	}
+
+	/**
+	 * Set up upgrader page only if there are items to upgrade.
+	 *
+	 * @since 1.2.0
+	 */
+	public function upgrader() {
+		// Ensure we're on a CBOX page.
+		if ( empty( $_GET['page'] ) || false === strpos( $_GET['page'], 'cbox' ) ) {
+			return;
+		}
+
+		// See if we have items to upgrade.
+		$items = CBOX\Upgrades\Upgrade_Registry::get_instance()->get_all_registered();
+		if ( empty( $items ) ) {
+			return;
+		}
+
+		require CBOX_PLUGIN_DIR . 'admin/upgrades/pages.php';
 	}
 
 	/** ACTIONS / SCREENS *********************************************/

--- a/admin/admin-loader.php
+++ b/admin/admin-loader.php
@@ -843,17 +843,13 @@ class CBox_Admin {
 	/**
 	 * Upgrade notice.
 	 *
-	 * This shows up when CBOX is upgraded through the WP updates panel and
-	 * when installed CBOX plugins have updates.
+	 * Displays a notice if WordPress needs to be updated to the CBOX
+	 * recommended version.
 	 *
 	 * @since 0.3
-	 *
-	 * @uses cbox_is_upgraded() To tell if CBOX has just upgraded.
-	 * @uses cbox_bump_revision_date() To bump the CBOX revision date in the DB.
+	 * @since 1.2.0 Now only shows if WordPress should be updated or not.
 	 */
 	private function upgrades() {
-		/** check if WordPress needs upgrading **********************************/
-
 		// get plugin dependency requirements
 		$requirements = Plugin_Dependencies::get_requirements();
 
@@ -878,79 +874,6 @@ class CBox_Admin {
 		<?php
 			return;
 		}
-
-		/** check if CBOX modules have updates **********************************/
-
-		// Don't show the rest of the upgrades block if we're still setting up.
-		if ( cbox_get_setup_step() ) {
-			return;
-		}
-
-		// include the CBOX Theme Installer
-		if ( ! class_exists( 'CBox_Theme_Installer' ) )
-			require( CBOX_PLUGIN_DIR . 'admin/theme-install.php' );
-
-		// get activated CBOX plugins that need updating
-		$active_cbox_plugins_need_update = CBox_Admin_Plugins::get_upgrades( 'active' );
-
-		// check for theme upgrades
-		$is_theme_upgrade = cbox_get_theme_to_update();
-
-		// no available upgrades, so stop!
-		if ( ! $active_cbox_plugins_need_update && ! $is_theme_upgrade ) {
-
-			// if CBOX just upgraded and has no plugin updates, bump CBOX revision date and reload using JS
-			// yeah, the JS redirect is a little ugly... should probably do this higher up the stack...
-			if ( cbox_is_upgraded() ) {
-				cbox_bump_revision_date();
-				echo '<script type="text/javascript">window.location = document.URL;</script>';
-			}
-
-			return;
-		}
-
-		/* we have upgrades available! */
-
-		// plugin count
-		$plugin_count = $total_count = count( $active_cbox_plugins_need_update );
-
-		// setup default upgrade URL
-		$url = wp_nonce_url( self_admin_url( 'admin.php?page=cbox&amp;cbox-action=upgrade' ), 'cbox_upgrade' );
-
-		// theme is available for upgrade
-		if ( ! empty( $active_cbox_plugins_need_update ) && ! empty( $is_theme_upgrade ) ) {
-			++$total_count;
-
-			// theme has update, so add an extra parameter to the querystring
-			$url = wp_nonce_url( self_admin_url( 'admin.php?page=cbox&amp;cbox-action=upgrade&amp;cbox-themes=' . $is_theme_upgrade ), 'cbox_upgrade' );
-
-			$message = sprintf( _n( '%d installed plugin and the theme have an update available. Click on the button below to upgrade.', '%d installed plugins and the theme have updates available. Click on the button below to upgrade.', $plugin_count, 'commons-in-a-box' ), $plugin_count );
-
-		// just plugins
-		} elseif ( ! empty( $active_cbox_plugins_need_update ) ) {
-			$message = sprintf( _n( '%d installed plugin has an update available. Click on the button below to upgrade.', '%d installed plugins have updates available. Click on the button below to upgrade.', $plugin_count, 'commons-in-a-box' ), $plugin_count );
-
-		// just themes
-		} else {
-			// theme has update, so switch up the upgrade URL
-			$url = wp_nonce_url( self_admin_url( 'admin.php?page=cbox&amp;cbox-action=upgrade-theme&amp;cbox-themes=' . $is_theme_upgrade ), 'cbox_upgrade_theme' );
-
-			$message = sprintf( __( 'The %s theme has an update available. Click on the button below to upgrade.', 'commons-in-a-box' ), cbox_get_theme_prop( 'name' ) );
-		}
-
-	?>
-		<div id="cbox-upgrades" class="secondary-panel">
-			<h2><?php printf( _n( 'Upgrade Available', 'Upgrades Available', $total_count, 'commons-in-a-box' ), $total_count ); ?></h2>
-
-			<div class="login postbox">
-				<div class="message">
-					<p><?php echo $message; ?>
-					<br />
-					<a class="button-secondary" href="<?php echo $url; ?>"><?php _e( 'Upgrade', 'commons-in-a-box' ); ?></a></p>
-				</div>
-			</div>
-		</div>
-	<?php
 	}
 
 	/**

--- a/admin/admin-loader.php
+++ b/admin/admin-loader.php
@@ -300,6 +300,11 @@ class CBox_Admin {
 					die();
 					break;
 
+				case 'upgrades-available' :
+					wp_redirect( cbox_admin_prop( 'url', 'admin.php?page=cbox-upgrades' ) );
+					die();
+					break;
+
 				case '' :
 					cbox_bump_revision_date();
 					$redirect = self_admin_url( 'admin.php?page=cbox' );
@@ -1131,7 +1136,13 @@ class CBox_Admin {
 				$disable_btn = 'cbox';
 				break;
 
-			case '' :
+			case 'upgrades-available' :
+				$notice_text = esc_html__( 'There are some upgrades available.', 'commons-in-a-box' );
+				$button_link = cbox_admin_prop( 'url', 'admin.php?page=cbox-upgrades' );
+				$button_text = esc_html__( 'Click here to update', 'commons-in-a-box' );
+				break;
+
+			default :
 				return;
 				break;
 		}

--- a/admin/functions.php
+++ b/admin/functions.php
@@ -185,11 +185,18 @@ function cbox_get_setup_step() {
 				$step = 'theme-prompt';
 			}
 		}
-
 	}
 
 	if ( empty( $step ) && cbox_get_theme_to_update() ) {
 		$step = 'theme-update';
+	}
+
+	// Upgrades.
+	if ( empty( $step ) ) {
+		$items = CBOX\Upgrades\Upgrade_Registry::get_instance()->get_all_registered();
+		if ( ! empty( $items ) ) {
+			$step = 'upgrades-available';
+		}
 	}
 
 	return $step;

--- a/admin/upgrades/list-table.php
+++ b/admin/upgrades/list-table.php
@@ -1,0 +1,125 @@
+<?php
+namespace CBOX\Admin\Upgrades;
+
+use CBOX\Upgrades\Upgrade_Registry;
+
+if ( ! class_exists( '\WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class List_Table extends \WP_List_Table {
+
+	/**
+	 * Constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		parent::__construct( [
+			'plural'   => 'upgrades',
+			'singular' => 'upgrade',
+			'ajax'     => false
+		] );
+	}
+
+	/**
+	 * Message to be displayed when there are no items.
+	 *
+	 * @return void
+	 */
+	public function no_items() {
+		_e( 'No upgrades found.', 'commons-in-a-box' );
+	}
+
+	/**
+	 * Get the list of columns.
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		$columns = [
+			'name'            => __( 'Name', 'commons-in-a-box' ),
+			'total_items'     => __( 'Total Items', 'commons-in-a-box' ),
+			'total_processed' => __( 'Total Processed', 'commons-in-a-box' ),
+		];
+
+		return $columns;
+	}
+
+	/**
+	 * Default column values if no callback found
+	 *
+	 * @param object $item
+	 * @param string $column_name
+	 *
+	 * @return string
+	 */
+	protected function column_default( $item, $column_name ) {
+		switch ( $column_name ) {
+			case 'name':
+				return $item->name;
+
+			case 'total_processed':
+				return $item->get_processed_count();
+
+			case 'total_items':
+				return $item->get_items_count();
+
+			default:
+				return isset( $item->$column_name ) ? $item->$column_name : '';
+		}
+	}
+
+	/**
+	 * Render the checkbox column
+	 *
+	 * @param object $item
+	 * @return string
+	 */
+	protected function column_cb( $item ) {
+		return '';
+	}
+
+	/**
+	 * Render the upgrade name column.
+	 *
+	 * @param object $item
+	 *
+	 * @return string
+	 */
+	public function column_name( $item ) {
+		$url = add_query_arg( [
+			'page'   => 'cbox-upgrades',
+			'action' => 'view',
+			'id'     => $item->id,
+		], self_admin_url( 'admin.php' ) );
+
+		$actions         = [];
+		$actions['edit'] = sprintf(
+			'<a href="%1$s" data-id="%2$d" title="%3$s">%4$s</a>',
+			esc_url( $url ),
+			esc_attr( $item->id ),
+			__( 'View Upgrade', 'commons-in-a-box' ),
+			__( 'View', 'commons-in-a-box' )
+		);
+
+		return sprintf(
+			'<a href="%1$s"><strong>%2$s</strong></a> %3$s',
+			esc_url( $url ),
+			esc_html( $item->name ),
+			$this->row_actions( $actions )
+		);
+	}
+
+	/**
+	 * Prepare the class items.
+	 *
+	 * @return void
+	 */
+	public function prepare_items() {
+		$columns               = $this->get_columns();
+		$this->_column_headers = [ $columns ];
+
+		$this->items = Upgrade_Registry::get_instance()->get_all_registered();
+	}
+}

--- a/admin/upgrades/list-table.php
+++ b/admin/upgrades/list-table.php
@@ -112,6 +112,34 @@ class List_Table extends \WP_List_Table {
 	}
 
 	/**
+	 * Extra controls to be displayed between bulk actions and pagination.
+	 *
+	 * @param string $which
+	 * @return void
+	 */
+	protected function extra_tablenav( $which ) {
+		if ( 'bottom' !== $which ) {
+			return;
+		}
+
+		if ( empty( $this->items ) ) {
+			return;
+		}
+
+		$url = add_query_arg( [
+			'page'   => 'cbox-upgrades',
+			'action' => 'view',
+			'id'     => 'all',
+		], self_admin_url( 'admin.php' ) );
+
+		printf(
+			'<a href="%1$s" class="button button-primary button-large">%2$s</a>',
+			esc_url( $url ),
+			__( 'Start upgrade process', 'commons-in-a-box' )
+		);
+	}
+
+	/**
 	 * Prepare the class items.
 	 *
 	 * @return void

--- a/admin/upgrades/list-table.php
+++ b/admin/upgrades/list-table.php
@@ -28,7 +28,7 @@ class List_Table extends \WP_List_Table {
 	 * @return void
 	 */
 	public function no_items() {
-		_e( 'No upgrades found.', 'commons-in-a-box' );
+		esc_html_e( 'No upgrades found.', 'commons-in-a-box' );
 	}
 
 	/**
@@ -38,9 +38,9 @@ class List_Table extends \WP_List_Table {
 	 */
 	public function get_columns() {
 		$columns = [
-			'name'            => __( 'Name', 'commons-in-a-box' ),
-			'total_items'     => __( 'Total Items', 'commons-in-a-box' ),
-			'total_processed' => __( 'Total Processed', 'commons-in-a-box' ),
+			'name'            => esc_html__( 'Name', 'commons-in-a-box' ),
+			'total_items'     => esc_html__( 'Total Items', 'commons-in-a-box' ),
+			'total_processed' => esc_html__( 'Total Processed', 'commons-in-a-box' ),
 		];
 
 		return $columns;
@@ -99,8 +99,8 @@ class List_Table extends \WP_List_Table {
 			'<a href="%1$s" data-id="%2$d" title="%3$s">%4$s</a>',
 			esc_url( $url ),
 			esc_attr( $item->id ),
-			__( 'View Upgrade', 'commons-in-a-box' ),
-			__( 'View', 'commons-in-a-box' )
+			esc_html__( 'View Upgrade', 'commons-in-a-box' ),
+			esc_html__( 'View', 'commons-in-a-box' )
 		);
 
 		return sprintf(

--- a/admin/upgrades/pages.php
+++ b/admin/upgrades/pages.php
@@ -1,0 +1,139 @@
+<?php
+namespace CBOX\Admin\Upgrades;
+
+use CBOX\Upgrades\Upgrade_Registry;
+use CBOX\Admin\Upgrades\List_Table;
+
+/**
+ * Setup sub-menu page for Upgrades.
+ *
+ * @return void
+ */
+function setup_upgrades_page() {
+	$subpage = add_submenu_page(
+		'cbox',
+		__( 'Upgrades', 'commons-in-a-box' ),
+		__( 'Upgrades', 'commons-in-a-box' ),
+		'install_plugins',
+		'cbox-upgrades',
+		__NAMESPACE__ . '\\upgrades_page'
+	);
+
+	add_action( "admin_print_scripts-{$subpage}", __NAMESPACE__ . '\\enqueue_assets' );
+}
+add_action( 'cbox_admin_menu', __NAMESPACE__ . '\\setup_upgrades_page' );
+
+/**
+ * Load upgrade page assets.
+ *
+ * @return void
+ */
+function enqueue_assets() {
+	wp_enqueue_style(
+		'cbox-upgrade-styles',
+		cbox()->plugin_url( 'assets/css/upgrades.css' ),
+		[],
+		cbox()->version
+	);
+
+	wp_enqueue_script(
+		'cbox-upgrade-script',
+		cbox()->plugin_url( 'assets/js/upgrades.js' ),
+		[ 'jquery' ],
+		cbox()->version,
+		true
+	);
+
+	wp_localize_script( 'cbox-upgrade-script', 'CBOXUpgrades', [
+		'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
+		'nonce'    => wp_create_nonce( 'cbox-upgrades' ),
+		'upgrade'  => isset( $_GET['id'] ) ? sanitize_key( $_GET['id'] ) : null,
+		'delay'    => 0,
+		'text'     => [
+			'processing' => __( 'Processing...', 'commons-in-a-box' ),
+			'start'      => __( 'Start', 'commons-in-a-box' ),
+		]
+	] );
+}
+
+/**
+ * Render "Upgrades" page.
+ *
+ * @return void
+ */
+function upgrades_page() {
+	$action = isset( $_GET['action'] ) ? $_GET['action'] : 'list';
+
+	?>
+	<div class="wrap">
+		<h2><?php esc_html_e( 'Upgrades', 'commons-in-a-box' ); ?></a></h2>
+		<?php if ( $action === 'view' ) : ?>
+			<?php upgrades_view(); ?>
+		<?php else : ?>
+			<?php upgrades_list_table(); ?>
+		<?php endif; ?>
+	</div>
+	<?php
+}
+
+/**
+ * Render "Upgrades" list table.
+ *
+ * @return void
+ */
+function upgrades_list_table() {
+	$list_table = new List_Table();
+	?>
+	<form method="get">
+		<?php $list_table->prepare_items(); ?>
+		<?php $list_table->display(); ?>
+	</form>
+	<?php
+}
+
+/**
+ * Render "Upgrades" singular view.
+ *
+ * @return void
+ */
+function upgrades_view() {
+	$id  = isset( $_GET['id'] ) ? sanitize_key( $_GET['id'] ) : null;
+
+	/** @var \CBOX\Upgrades\Upgrade */
+	$upgrade = Upgrade_Registry::get_instance()->get_registered( $id );
+
+	if ( ! $upgrade ) {
+		_e( 'Upgrade doesn\'t exists!' );
+		return;
+	}
+
+	$percentage = $upgrade->get_percentage();
+	$style      = $percentage > 0 ? 'style="width: '.$percentage.'%"' : '';
+	?>
+	<div class="cbox-upgrade">
+		<h3><?php echo esc_html( $upgrade->name ); ?></h3>
+		<div class="cbox-upgrade-main">
+			<ul class="cbox-upgrade-stats">
+				<li>
+					<strong><?php esc_html_e( 'Total', 'commons-in-a-box' ); ?></strong> <span id="cbox-upgrade-total"><?php echo $upgrade->get_items_count(); ?></span>
+				</li>
+				<li>
+					<strong><?php esc_html_e( 'Processed', 'commons-in-a-box' ); ?></strong> <span id="cbox-upgrade-processed"><?php echo $upgrade->get_processed_count(); ?></span> <span id="cbox-upgrade-percentage">(<?php echo $percentage; ?>%)</span>
+				</li>
+			</ul>
+			<div class="cbox-upgrade-progress-bar">
+				<div class="cbox-upgrade-progress-bar-inner" <?php echo $style; ?>></div>
+			</div>
+			<div class="cbox-upgrade-current-item"></div>
+		</div>
+		<div class="cbox-upgrade-actions">
+			<?php if ( ! $upgrade->is_finished() ) : ?>
+				<button class="button-primary" id="cbox-upgrade-start"><?php esc_html_e( 'Start', 'commons-in-a-box' ); ?></button>
+				<button class="button" id="cbox-upgrade-pause"><?php esc_html_e( 'Pause', 'commons-in-a-box' ); ?></button>
+			<?php else: ?>
+				<button class="button-primary" id="cbox-upgrade-restart"><?php esc_html_e( 'Restart', 'commons-in-a-box' ); ?></button>
+			<?php endif; ?>
+		</div>
+	</div>
+	<?php
+}

--- a/admin/upgrades/pages.php
+++ b/admin/upgrades/pages.php
@@ -12,8 +12,8 @@ use CBOX\Admin\Upgrades\List_Table;
 function setup_upgrades_page() {
 	$subpage = add_submenu_page(
 		'cbox',
-		__( 'Upgrades', 'commons-in-a-box' ),
-		__( 'Upgrades', 'commons-in-a-box' ),
+		esc_html__( 'Upgrades', 'commons-in-a-box' ),
+		esc_html__( 'Upgrades', 'commons-in-a-box' ),
 		'install_plugins',
 		'cbox-upgrades',
 		__NAMESPACE__ . '\\upgrades_page'
@@ -50,8 +50,8 @@ function enqueue_assets() {
 		'upgrade'  => isset( $_GET['id'] ) ? sanitize_key( $_GET['id'] ) : null,
 		'delay'    => 0,
 		'text'     => [
-			'processing' => __( 'Processing...', 'commons-in-a-box' ),
-			'start'      => __( 'Start', 'commons-in-a-box' ),
+			'processing' => esc_html__( 'Processing...', 'commons-in-a-box' ),
+			'start'      => esc_html__( 'Start', 'commons-in-a-box' ),
 		]
 	] );
 }
@@ -103,7 +103,7 @@ function upgrades_view() {
 	$upgrade = Upgrade_Registry::get_instance()->get_registered( $id );
 
 	if ( ! $upgrade ) {
-		_e( 'Upgrade doesn\'t exists!' );
+		esc_html_e( 'Upgrade doesn\'t exists!' );
 		return;
 	}
 

--- a/admin/upgrades/pages.php
+++ b/admin/upgrades/pages.php
@@ -82,6 +82,8 @@ function upgrades_page() {
  * @return void
  */
 function upgrades_list_table() {
+	require CBOX_PLUGIN_DIR . 'admin/upgrades/list-table.php';
+
 	$list_table = new List_Table();
 	?>
 	<form method="get">

--- a/admin/upgrades/pages.php
+++ b/admin/upgrades/pages.php
@@ -99,13 +99,21 @@ function upgrades_list_table() {
  * @return void
  */
 function upgrades_view() {
-	$id  = isset( $_GET['id'] ) ? sanitize_key( $_GET['id'] ) : null;
+	$id       = isset( $_GET['id'] ) ? sanitize_key( $_GET['id'] ) : null;
+	$registry = Upgrade_Registry::get_instance();
 
-	/** @var \CBOX\Upgrades\Upgrade */
-	$upgrade = Upgrade_Registry::get_instance()->get_registered( $id );
+	if ( $id === 'all' ) {
+		$upgrades = $registry->get_all_registered();
+
+		/** @var \CBOX\Upgrades\Upgrade */
+		$upgrade = ! empty( $upgrades ) ? reset( $upgrades ) : null;
+	} else {
+		/** @var \CBOX\Upgrades\Upgrade */
+		$upgrade = $registry->get_registered( $id );
+	}
 
 	if ( ! $upgrade ) {
-		esc_html_e( 'Upgrade doesn\'t exists!' );
+		esc_html_e( 'Upgrade doesn\'t exists!', 'commons-in-a-box' );
 		return;
 	}
 

--- a/admin/upgrades/pages.php
+++ b/admin/upgrades/pages.php
@@ -101,8 +101,9 @@ function upgrades_list_table() {
 function upgrades_view() {
 	$id       = isset( $_GET['id'] ) ? sanitize_key( $_GET['id'] ) : null;
 	$registry = Upgrade_Registry::get_instance();
+	$is_bulk  = $id === 'all';
 
-	if ( $id === 'all' ) {
+	if ( $is_bulk ) {
 		$upgrades = $registry->get_all_registered();
 
 		/** @var \CBOX\Upgrades\Upgrade */
@@ -117,18 +118,24 @@ function upgrades_view() {
 		return;
 	}
 
+	$name       = $is_bulk ? __( 'Bulk upgrade', 'commons-in-a-box' ) : $upgrade->name;
 	$percentage = $upgrade->get_percentage();
 	$style      = $percentage > 0 ? 'style="width: '.$percentage.'%"' : '';
 	?>
 	<div class="cbox-upgrade">
-		<h3><?php echo esc_html( $upgrade->name ); ?></h3>
+		<h3><?php echo esc_html( $name ); ?></h3>
 		<div class="cbox-upgrade-main">
 			<ul class="cbox-upgrade-stats">
+				<?php if ( $is_bulk ) : ?>
+					<li>
+					<strong><?php esc_html_e( 'Name:', 'commons-in-a-box' ); ?></strong> <span id="cbox-upgrade-name"><?php echo esc_html( $upgrade->name ); ?></span>
+				</li>
+				<?php endif; ?>
 				<li>
-					<strong><?php esc_html_e( 'Total', 'commons-in-a-box' ); ?></strong> <span id="cbox-upgrade-total"><?php echo $upgrade->get_items_count(); ?></span>
+					<strong><?php esc_html_e( 'Total:', 'commons-in-a-box' ); ?></strong> <span id="cbox-upgrade-total"><?php echo $upgrade->get_items_count(); ?></span>
 				</li>
 				<li>
-					<strong><?php esc_html_e( 'Processed', 'commons-in-a-box' ); ?></strong> <span id="cbox-upgrade-processed"><?php echo $upgrade->get_processed_count(); ?></span> <span id="cbox-upgrade-percentage">(<?php echo $percentage; ?>%)</span>
+					<strong><?php esc_html_e( 'Processed:', 'commons-in-a-box' ); ?></strong> <span id="cbox-upgrade-processed"><?php echo $upgrade->get_processed_count(); ?></span> <span id="cbox-upgrade-percentage">(<?php echo $percentage; ?>%)</span>
 				</li>
 			</ul>
 			<div class="cbox-upgrade-progress-bar">

--- a/admin/upgrades/pages.php
+++ b/admin/upgrades/pages.php
@@ -137,12 +137,8 @@ function upgrades_view() {
 			<div class="cbox-upgrade-current-item"></div>
 		</div>
 		<div class="cbox-upgrade-actions">
-			<?php if ( ! $upgrade->is_finished() ) : ?>
-				<button class="button-primary" id="cbox-upgrade-start"><?php esc_html_e( 'Start', 'commons-in-a-box' ); ?></button>
-				<button class="button" id="cbox-upgrade-pause"><?php esc_html_e( 'Pause', 'commons-in-a-box' ); ?></button>
-			<?php else: ?>
-				<button class="button-primary" id="cbox-upgrade-restart"><?php esc_html_e( 'Restart', 'commons-in-a-box' ); ?></button>
-			<?php endif; ?>
+			<button class="button-primary" id="cbox-upgrade-start"><?php esc_html_e( 'Start', 'commons-in-a-box' ); ?></button>
+			<button class="button" id="cbox-upgrade-pause"><?php esc_html_e( 'Pause', 'commons-in-a-box' ); ?></button>
 		</div>
 	</div>
 	<?php

--- a/admin/upgrades/pages.php
+++ b/admin/upgrades/pages.php
@@ -121,6 +121,7 @@ function upgrades_view() {
 	$name       = $is_bulk ? __( 'Bulk upgrade', 'commons-in-a-box' ) : $upgrade->name;
 	$percentage = $upgrade->get_percentage();
 	$style      = $percentage > 0 ? 'style="width: '.$percentage.'%"' : '';
+	$go_back    = cbox_admin_prop( 'url', 'admin.php?page=cbox-upgrades' );
 	?>
 	<div class="cbox-upgrade">
 		<h3><?php echo esc_html( $name ); ?></h3>
@@ -148,5 +149,8 @@ function upgrades_view() {
 			<button class="button" id="cbox-upgrade-pause"><?php esc_html_e( 'Pause', 'commons-in-a-box' ); ?></button>
 		</div>
 	</div>
+	<p>
+		<a href="<?php echo esc_url( $go_back ); ?>" class="button button-primary"><?php esc_html_e( 'Go back', 'commons-in-a-box' ); ?></a>
+	</p>
 	<?php
 }

--- a/assets/css/upgrades.css
+++ b/assets/css/upgrades.css
@@ -1,0 +1,52 @@
+.cbox-upgrade {
+	background: #fff;
+	border: 1px solid #ccd0d4;
+	padding: 1px;
+	margin-top: 10px;
+}
+
+.cbox-upgrade h3 {
+	border-bottom: 1px solid #eee;
+	font-size: 1em;
+	margin-bottom: 0;
+	margin-top: 0;
+	padding: 8px 20px;
+}
+
+.cbox-upgrade-main {
+	padding: 10px 20px;
+	border-bottom: 1px solid #eee;
+}
+
+.cbox-upgrade-stats {
+	list-style: none;
+	margin-top: 0;
+}
+
+.cbox-upgrade-progress-bar-inner {
+	position: absolute;
+	background: #0073aa;
+	width: 0;
+	height: 100%;
+	left: 0;
+}
+
+.cbox-upgrade-progress-bar {
+	background: #f0f0f0;
+	min-height: 20px;
+	position: relative;
+}
+
+.cbox-upgrade-actions {
+	padding: 10px 20px;
+}
+
+.cbox-upgrade-current-item {
+	text-align: center;
+}
+
+.cbox-upgrade-current-item {
+	padding-top: 5px;
+	padding-bottom: 5px;
+	min-height: 12px;
+}

--- a/assets/js/upgrades.js
+++ b/assets/js/upgrades.js
@@ -4,24 +4,8 @@
 		window.location.href = window.location.href;
 	};
 
-	// @todo maybe actually cancel next 'itemprocessed' event.
 	function pauseUpgrade() {
 		reloadPage();
-	};
-
-	function restartUpgrade() {
-		$.ajax({
-			url: ajaxurl,
-			type: 'POST',
-			data: {
-				_ajax_nonce: CBOXUpgrades.nonce,
-				action: 'cbox_restart_upgrade',
-				upgrade: CBOXUpgrades.upgrade
-			},
-			success: function() {
-				reloadPage();
-			}
-		});
 	};
 
 	function processNextItem() {
@@ -73,5 +57,4 @@
 
 	$(document).on( 'click', '#cbox-upgrade-start', processNextItem );
 	$(document).on( 'click', '#cbox-upgrade-pause', pauseUpgrade );
-	$(document).on( 'click', '#cbox-upgrade-restart', restartUpgrade );
 } )( jQuery );

--- a/assets/js/upgrades.js
+++ b/assets/js/upgrades.js
@@ -42,12 +42,14 @@
 		var data = response.data;
 		var percentage = data.percentage;
 
-		$('.cbox-upgrade').find('h3').text( data.name );
+		if ( data.name ) {
+			$('#cbox-upgrade-name').text( data.name );
+		}
+
 		$('.cbox-upgrade-progress-bar-inner').css( 'width', percentage +'%' );
 		$('#cbox-upgrade-total').text( data.total_items );
 		$('#cbox-upgrade-processed').text( data.total_processed );
 		$('#cbox-upgrade-percentage').text( '(' +percentage+ '%)' );
-
 		$('.cbox-upgrade-current-item').html(data.message);
 
 		if ( data.is_finished ) {

--- a/assets/js/upgrades.js
+++ b/assets/js/upgrades.js
@@ -58,6 +58,7 @@
 		var data = response.data;
 		var percentage = data.percentage;
 
+		$('.cbox-upgrade').find('h3').text( data.name );
 		$('.cbox-upgrade-progress-bar-inner').css( 'width', percentage +'%' );
 		$('#cbox-upgrade-total').text( data.total_items );
 		$('#cbox-upgrade-processed').text( data.total_processed );

--- a/assets/js/upgrades.js
+++ b/assets/js/upgrades.js
@@ -1,0 +1,76 @@
+( function( $ ){
+
+	function reloadPage() {
+		window.location.href = window.location.href;
+	};
+
+	// @todo maybe actually cancel next 'itemprocessed' event.
+	function pauseUpgrade() {
+		reloadPage();
+	};
+
+	function restartUpgrade() {
+		$.ajax({
+			url: ajaxurl,
+			type: 'POST',
+			data: {
+				_ajax_nonce: CBOXUpgrades.nonce,
+				action: 'cbox_restart_upgrade',
+				upgrade: CBOXUpgrades.upgrade
+			},
+			success: function() {
+				reloadPage();
+			}
+		});
+	};
+
+	function processNextItem() {
+		$.ajax({
+			url: ajaxurl,
+			type: 'POST',
+			data: {
+				_ajax_nonce: CBOXUpgrades.nonce,
+				action: 'cbox_handle_upgrade',
+				upgrade: CBOXUpgrades.upgrade
+			},
+			beforeSend: function() {
+				$('#cbox-upgrade-start')
+					.text( CBOXUpgrades.text.processing )
+					.prop( 'disabled', true );
+			},
+			success: function( response ) {
+				$(document).trigger( 'itemprocessed', [ response ] )
+
+				if ( ! response.data.is_finished ) {
+					processNextItem();
+				} else {
+					$('#cbox-upgrade-start').text( CBOXUpgrades.text.start );
+				}
+			},
+			error: function( error ) {
+				console.log( error );
+			},
+		});
+
+	}
+
+	$(document).on( 'itemprocessed', function( event, response ) {
+		var data = response.data;
+		var percentage = data.percentage;
+
+		$('.cbox-upgrade-progress-bar-inner').css( 'width', percentage +'%' );
+		$('#cbox-upgrade-total').text( data.total_items );
+		$('#cbox-upgrade-processed').text( data.total_processed );
+		$('#cbox-upgrade-percentage').text( '(' +percentage+ '%)' );
+
+		$('.cbox-upgrade-current-item').html(data.message);
+
+		if ( data.is_finished ) {
+			$('#cbox-upgrade-start, #cbox-upgrade-pause').prop( 'disabled', true );
+		}
+	} );
+
+	$(document).on( 'click', '#cbox-upgrade-start', processNextItem );
+	$(document).on( 'click', '#cbox-upgrade-pause', pauseUpgrade );
+	$(document).on( 'click', '#cbox-upgrade-restart', restartUpgrade );
+} )( jQuery );

--- a/includes/openlab/openlab.php
+++ b/includes/openlab/openlab.php
@@ -82,6 +82,15 @@ class CBox_Package_OpenLab extends CBox_Package {
 	}
 
 	/**
+	 * Register upgrader.
+	 *
+	 * @since 1.2.0
+	 */
+	public static function upgrader() {
+		do_action( 'cboxol_register_upgrader' );
+	}
+
+	/**
 	 * Callback for forcing the Plugins page to be available to non-super-admins.
 	 *
 	 * @since 1.1.1

--- a/includes/package.php
+++ b/includes/package.php
@@ -109,9 +109,6 @@ abstract class CBox_Package {
 				}
 			} );
 		} );
-
-		// Register upgrade steps in admin area.
-		add_action( 'cbox_admin_loaded', array( get_called_class(), 'upgrader' ), 15 );
 	}
 
 	/**

--- a/includes/package.php
+++ b/includes/package.php
@@ -109,6 +109,9 @@ abstract class CBox_Package {
 				}
 			} );
 		} );
+
+		// Register upgrade steps in admin area.
+		add_action( 'cbox_admin_loaded', array( get_called_class(), 'upgrader' ), 15 );
 	}
 
 	/**
@@ -280,6 +283,13 @@ abstract class CBox_Package {
 	 * @since 1.1.0
 	 */
 	protected function custom_init() {}
+
+	/**
+	 * Register upgrade steps here.
+	 *
+	 * @since 1.2.0
+	 */
+	public static function upgrader() {}
 
 	/**
 	 * Deactivation method, extend if necessary.

--- a/includes/upgrades/ajax-handler.php
+++ b/includes/upgrades/ajax-handler.php
@@ -11,7 +11,7 @@ use CBOX\Upgrades\Upgrade_Registry;
 function handle_upgrade() {
 	if ( ! check_ajax_referer( 'cbox-upgrades', '_ajax_nonce', false ) ) {
 		wp_send_json_error( [
-			'message' => __( 'Permission denied.', 'commons-in-a-box' ),
+			'message' => esc_html__( 'Permission denied.', 'commons-in-a-box' ),
 		] );
 	}
 
@@ -19,7 +19,7 @@ function handle_upgrade() {
 	$upgrade_id = isset( $_POST['upgrade'] ) ? sanitize_key( $_POST['upgrade'] ) : false;
 	if ( ! $upgrade_id ) {
 		wp_send_json_error( [
-			'message' => __( 'Invalid upgrade ID.', 'commons-in-a-box' ),
+			'message' => esc_html__( 'Invalid upgrade ID.', 'commons-in-a-box' ),
 		] );
 	}
 
@@ -34,7 +34,7 @@ function handle_upgrade() {
 		$upgrade->finish();
 
 		wp_send_json_success( [
-			'message'         => __( 'Processing finished.', 'commons-in-a-box' ),
+			'message'         => esc_html__( 'Processing finished.', 'commons-in-a-box' ),
 			'is_finished'     => 1,
 			'total_processed' => $upgrade->get_processed_count(),
 			'total_items'     => $upgrade->get_items_count(),
@@ -61,11 +61,14 @@ function handle_upgrade() {
 	}
 
 	wp_send_json_success( [
-		'message'         => sprintf( __( 'Processed item with ID: %d.', 'commons-in-a-box' ), $next_item->id ),
 		'is_finished'     => 0,
 		'total_processed' => $total_processed,
 		'total_items'     => $total_items,
 		'percentage'      => $percentage,
+		'message'         => sprintf(
+			esc_html__( 'Processed item with ID: %d.', 'commons-in-a-box' ),
+			$next_item->id
+		),
 	] );
 }
 add_action( 'wp_ajax_cbox_handle_upgrade', __NAMESPACE__ . '\\handle_upgrade' );
@@ -78,7 +81,7 @@ add_action( 'wp_ajax_cbox_handle_upgrade', __NAMESPACE__ . '\\handle_upgrade' );
 function restart_upgrade() {
 	if ( ! check_ajax_referer( 'cbox-upgrades', '_ajax_nonce', false ) ) {
 		wp_send_json_error( [
-			'message' => __( 'Permission denied.', 'commons-in-a-box' ),
+			'message' => esc_html__( 'Permission denied.', 'commons-in-a-box' ),
 		] );
 	}
 
@@ -86,7 +89,7 @@ function restart_upgrade() {
 	$upgrade_id = isset( $_POST['upgrade'] ) ? sanitize_key( $_POST['upgrade'] ) : false;
 	if ( ! $upgrade_id ) {
 		wp_send_json_error( [
-			'message' => __( 'Invalid upgrade ID.', 'commons-in-a-box' ),
+			'message' => esc_html__( 'Invalid upgrade ID.', 'commons-in-a-box' ),
 		] );
 	}
 

--- a/includes/upgrades/ajax-handler.php
+++ b/includes/upgrades/ajax-handler.php
@@ -23,9 +23,10 @@ function handle_upgrade() {
 		] );
 	}
 
+	$is_bulk  = $id === 'all';
 	$registry = Upgrade_Registry::get_instance();
 
-	if ( $id === 'all' ) {
+	if ( $is_bulk ) {
 		$upgrades = $registry->get_all_registered();
 
 		/** @var \CBOX\Upgrades\Upgrade */
@@ -46,11 +47,11 @@ function handle_upgrade() {
 
 		wp_send_json_success( [
 			'message'         => esc_html__( 'Processing finished.', 'commons-in-a-box' ),
-			'is_finished'     => ( $id === 'all' && $total > 1 ) ? 0 : 1,
+			'is_finished'     => ( $is_bulk && $total > 1 ) ? 0 : 1,
 			'total_processed' => $upgrade->get_processed_count(),
 			'total_items'     => $upgrade->get_items_count(),
 			'percentage'      => $upgrade->get_percentage(),
-			'name'            => $upgrade->name,
+			'name'            => $is_bulk ? $upgrade->name : null,
 		] );
 	}
 
@@ -70,12 +71,12 @@ function handle_upgrade() {
 			'total_processed' => $total_processed,
 			'total_items'     => $total_items,
 			'percentage'      => $percentage,
-			'name'            => $name,
+			'name'            => $is_bulk ? $name : null,
 		] );
 	}
 
 	wp_send_json_success( [
-		'name'            => $name,
+		'name'            => $is_bulk ? $name : null,
 		'is_finished'     => 0,
 		'total_processed' => $total_processed,
 		'total_items'     => $total_items,

--- a/includes/upgrades/ajax-handler.php
+++ b/includes/upgrades/ajax-handler.php
@@ -87,31 +87,3 @@ function handle_upgrade() {
 	] );
 }
 add_action( 'wp_ajax_cbox_handle_upgrade', __NAMESPACE__ . '\\handle_upgrade' );
-
-/**
- * AJAX callback for upgrade reset.
- *
- * @return void
- */
-function restart_upgrade() {
-	if ( ! check_ajax_referer( 'cbox-upgrades', '_ajax_nonce', false ) ) {
-		wp_send_json_error( [
-			'message' => esc_html__( 'Permission denied.', 'commons-in-a-box' ),
-		] );
-	}
-
-	// Check the upgrade id.
-	$upgrade_id = isset( $_POST['upgrade'] ) ? sanitize_key( $_POST['upgrade'] ) : false;
-	if ( ! $upgrade_id ) {
-		wp_send_json_error( [
-			'message' => esc_html__( 'Invalid upgrade ID.', 'commons-in-a-box' ),
-		] );
-	}
-
-	/** @var \CBOX\Upgrades\Upgrade */
-	$upgrade = Upgrade_Registry::get_instance()->get_registered( $upgrade_id );
-	$upgrade->restart();
-
-	wp_send_json_success();
-}
-add_action( 'wp_ajax_cbox_restart_upgrade', __NAMESPACE__ . '\\restart_upgrade' );

--- a/includes/upgrades/ajax-handler.php
+++ b/includes/upgrades/ajax-handler.php
@@ -1,0 +1,99 @@
+<?php
+namespace CBOX\Upgrades;
+
+use CBOX\Upgrades\Upgrade_Registry;
+
+/**
+ * AJAX callback for upgrade process.
+ *
+ * @return void
+ */
+function handle_upgrade() {
+	if ( ! check_ajax_referer( 'cbox-upgrades', '_ajax_nonce', false ) ) {
+		wp_send_json_error( [
+			'message' => __( 'Permission denied.', 'commons-in-a-box' ),
+		] );
+	}
+
+	// Check the upgrade id.
+	$upgrade_id = isset( $_POST['upgrade'] ) ? sanitize_key( $_POST['upgrade'] ) : false;
+	if ( ! $upgrade_id ) {
+		wp_send_json_error( [
+			'message' => __( 'Invalid upgrade ID.', 'commons-in-a-box' ),
+		] );
+	}
+
+	/** @var \CBOX\Upgrades\Upgrade */
+	$upgrade = Upgrade_Registry::get_instance()->get_registered( $upgrade_id );
+
+	// Process the next item.
+	$next_item = $upgrade->get_next_item();
+
+	// No next item for processing. The upgrade processing is finished, probably.
+	if ( ! $next_item ) {
+		$upgrade->finish();
+
+		wp_send_json_success( [
+			'message'         => __( 'Processing finished.', 'commons-in-a-box' ),
+			'is_finished'     => 1,
+			'total_processed' => $upgrade->get_processed_count(),
+			'total_items'     => $upgrade->get_items_count(),
+			'percentage'      => $upgrade->get_percentage(),
+		] );
+	}
+
+	@set_time_limit( 0 );
+
+	$response = $upgrade->process( $next_item );
+	$upgrade->mark_as_processed( $next_item->id );
+	$total_processed = $upgrade->get_processed_count();
+	$total_items     = $upgrade->get_items_count();
+	$percentage      = $upgrade->get_percentage();
+
+	if ( is_wp_error( $response ) ) {
+		wp_send_json_error( [
+			'message'         => $response->get_error_message(),
+			'is_finished'     => 0,
+			'total_processed' => $total_processed,
+			'total_items'     => $total_items,
+			'percentage'      => $percentage,
+		] );
+	}
+
+	wp_send_json_success( [
+		'message'         => sprintf( __( 'Processed item with ID: %d.', 'commons-in-a-box' ), $next_item->id ),
+		'is_finished'     => 0,
+		'total_processed' => $total_processed,
+		'total_items'     => $total_items,
+		'percentage'      => $percentage,
+	] );
+}
+add_action( 'wp_ajax_cbox_handle_upgrade', __NAMESPACE__ . '\\handle_upgrade' );
+
+/**
+ * AJAX callback for upgrade reset.
+ *
+ * @return void
+ */
+function restart_upgrade() {
+	if ( ! check_ajax_referer( 'cbox-upgrades', '_ajax_nonce', false ) ) {
+		wp_send_json_error( [
+			'message' => __( 'Permission denied.', 'commons-in-a-box' ),
+		] );
+	}
+
+	// Check the upgrade id.
+	$upgrade_id = isset( $_POST['upgrade'] ) ? sanitize_key( $_POST['upgrade'] ) : false;
+	if ( ! $upgrade_id ) {
+		wp_send_json_error( [
+			'message' => __( 'Invalid upgrade ID.', 'commons-in-a-box' ),
+		] );
+	}
+
+	/** @var \CBOX\Upgrades\Upgrade */
+	$upgrade = Upgrade_Registry::get_instance()->get_registered( $upgrade_id );
+	$upgrade->restart();
+
+	wp_send_json_success();
+}
+add_action( 'wp_ajax_cbox_restart_upgrade', __NAMESPACE__ . '\\restart_upgrade' );

--- a/includes/upgrades/upgrade-item.php
+++ b/includes/upgrades/upgrade-item.php
@@ -1,0 +1,42 @@
+<?php
+namespace CBOX\Upgrades;
+
+class Upgrade_Item {
+
+	/**
+	 * Unique identifier of the upgrade item.
+	 *
+	 * @var int
+	 */
+	public $id;
+
+	/**
+	 * Additional data for the item
+	 *
+	 * @var array
+	 */
+	public $data;
+
+	/**
+	 * Constructor
+	 *
+	 * @param int   $id   Unique identifier of the upgrade item.
+	 * @param array $data Additional data for the item.
+	 */
+	public function __construct( $id, $data = [] ) {
+		$this->id = $id;
+		$this->data = $data;
+	}
+
+	/**
+	 * Return data value
+	 *
+	 * @param string $key
+	 * @param null   $default
+	 *
+	 * @return mixed|null
+	 */
+	public function get_value( $key, $default = null ) {
+		return isset( $this->data[ $key ] ) ? $this->data[ $key ] : $default;
+	}
+}

--- a/includes/upgrades/upgrade-registry.php
+++ b/includes/upgrades/upgrade-registry.php
@@ -1,0 +1,81 @@
+<?php
+namespace CBOX\Upgrades;
+
+class Upgrade_Registry {
+
+	/**
+	 * Registered upgrades.
+	 *
+	 * @var CBOX\Upgrades\Upgrade[]
+	 */
+	private $upgrades = [];
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @var CBOX\Upgrades\Upgrade_Registry|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Register a upgrade.
+	 *
+	 * @param string                $id    Unique identifier of the upgrade.
+	 * @param CBOX\Upgrades\Upgrade $upgrade Upgrade object.
+	 * @return bool
+	 */
+	public function register( $id, $upgrade ) {
+		// @todo check if name is valid, etc.
+		$this->upgrades[ $id ] = $upgrade;
+
+		return true;
+	}
+
+	/**
+	 * Retrieves a registered upgrade.
+	 *
+	 * @param string $id Upgrade id.
+	 * @return CBOX\Upgrades\Upgrade|null The registered upgrade, or null if it is not registered.
+	 */
+	public function get_registered( $id ) {
+		if ( ! $this->is_registered( $id ) ) {
+			return null;
+		}
+
+		return $this->upgrades[ $id ];
+	}
+
+	/**
+	 * Retrieves all registered upgrades.
+	 *
+	 * @return CBOX\Upgrades\Upgrade[] Associative array of `$upgrade_id => $upgrade` pairs.
+	 */
+	public function get_all_registered() {
+		return $this->upgrades;
+	}
+
+	/**
+	 * Checks if a upgrade is registered.
+	 *
+	 * @param string $id Upgrade name.
+	 * @return bool True if the upgrade is registered, false otherwise.
+	 */
+	public function is_registered( $id ) {
+		return isset( $this->upgrades[ $id ] );
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @return CBOX\Upgrades\Upgrade_Registry The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+}

--- a/includes/upgrades/upgrade.php
+++ b/includes/upgrades/upgrade.php
@@ -1,0 +1,198 @@
+<?php
+namespace CBOX\Upgrades;
+
+/**
+ * CBOX\Upgrades\Upgrade class.
+ *
+ * Extend this class to create custom upgrades.
+ *
+ * Note: Upgrades must be registered via 'init' action.
+ *
+ * Example:
+ * Upgrade_Registry::get_instance()->register( $id, $upgrade ).
+ */
+abstract class Upgrade {
+
+	/**
+	 * Unique identifier for upgrade.
+	 *
+	 * @var string
+	 */
+	public $id = 'abstract_upgrade';
+
+	/**
+	 * Upgrade name/description.
+	 *
+	 * @var string
+	 */
+	public $name = 'Abstract Upgrade';
+
+	/**
+	 * Data store of upgrade items.
+	 *
+	 * @var CBOX\Upgrades\Upgrade_Item[]
+	 */
+	protected $items = [];
+
+	/**
+	 * Initialize.
+	 */
+	public function __construct() {
+		$this->setup();
+	}
+
+	/**
+	 * To setup the upgrade data use the push() method to add CBOX\Upgrades\Upgrade_Item instances to the queue.
+	 *
+	 * Note: If the operation of obtaining data is expensive, cache it to avoid slowdowns.
+	 *
+	 * @return void
+	 */
+	abstract public function setup();
+
+	/**
+	 * Handles processing of upgrade item. One at a time.
+	 *
+	 * In order to work it correctly you must return values as follows:
+	 *
+	 * - true - If the item was processed successfully.
+	 * - WP_Error instance - If there was an error. Add message to display it in the admin area.
+	 *
+	 * @param CBOX\Upgrades\Upgrade_Item $item
+	 *
+	 * @return \WP_Error|bool
+	 */
+	abstract public function process( $item );
+
+	/**
+	 * Called when specific process is finished (all items were processed).
+	 * This method can be overriden in the process class.
+	 *
+	 * @return void
+	 */
+	public function finish() {}
+
+	/**
+	 * Queues the item for processing.
+	 *
+	 * @param CBOX\Upgrades\Upgrade_Item $item
+	 */
+	protected function push( $item ) {
+		if ( ! is_array( $this->items ) ) {
+			$this->items = [];
+		}
+
+		$this->items[] = $item;
+	}
+
+
+	/**
+	 * Get next upgrade item.
+	 *
+	 * @param CBOX\Upgrades\Upgrade_Item $item
+	 *
+	 * @return CBOX\Upgrades\Upgrade_Item|bool
+	 */
+	public function get_next_item() {
+		$processed = $this->get_processed_items();
+
+		foreach ( $this->items as $item ) {
+			if ( ! in_array( $item->id, $processed ) ) {
+				return $item;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the upgrade is finished.
+	 *
+	 * @return bool
+	 */
+	public function is_finished() {
+		return ! $this->get_next_item();
+	}
+
+
+	/**
+	 * Check if upgrade item was processed.
+	 *
+	 * @param CBOX\Upgrades\Upgrade_Item $item
+	 *
+	 * @return bool
+	 */
+	public function is_processed( $item ) {
+		return in_array( $item->id, $this->get_processed_items() );
+	}
+
+	/**
+	 * Returns processed upgrade item ids.
+	 *
+	 * @return array
+	 */
+	public function get_processed_items() {
+		$processed = get_option( $this->get_db_identifier(), [] );
+
+		return $processed;
+	}
+
+	/**
+	 * Returns the count of the processed items.
+	 *
+	 * @return int
+	 */
+	public function get_processed_count() {
+		return count( $this->get_processed_items() );
+	}
+
+	/**
+	 * Mark specific item as processed.
+	 *
+	 * @param int $id Item ID.
+	 */
+	public function mark_as_processed( $id ) {
+		$processed = $this->get_processed_items();
+		array_push( $processed, $id );
+		$processed = array_unique( $processed );
+		update_option( $this->get_db_identifier(), $processed );
+	}
+
+	/**
+	 * Returns the count of the total items.
+	 *
+	 * @return int
+	 */
+	public function get_items_count() {
+		return count( $this->items );
+	}
+
+	/**
+	 * Returns the percentage.
+	 *
+	 * @return float
+	 */
+	public function get_percentage() {
+		$total_items     = $this->get_items_count();
+		$total_processed = $this->get_processed_count();
+		$percentage      = ( ! empty( $total_items ) ) ? 100 - ( ( ( $total_items - $total_processed ) / $total_items ) * 100 ) : 0;
+
+		return number_format( (float) $percentage, 2, '.', '' );
+	}
+
+	/**
+	 * Returns the upgrade identifier for WP options.
+	 *
+	 * @return string
+	 */
+	public function get_db_identifier() {
+		return 'upgrade_' . $this->id;
+	}
+
+	/**
+	 * Restarts the processed items store.
+	 */
+	public function restart() {
+		delete_option( $this->get_db_identifier() );
+	}
+}

--- a/includes/upgrades/upgrade.php
+++ b/includes/upgrades/upgrade.php
@@ -14,6 +14,13 @@ namespace CBOX\Upgrades;
 abstract class Upgrade {
 
 	/**
+	 * Upgrade task flag. Marks if upgrade is finished.
+	 *
+	 * @var string
+	 */
+	const FLAG = 'abstract_upgrade_flag';
+
+	/**
 	 * Unique identifier for upgrade.
 	 *
 	 * @var string
@@ -111,7 +118,7 @@ abstract class Upgrade {
 	 * @return bool
 	 */
 	public function is_finished() {
-		return ! $this->get_next_item();
+		return (bool) get_option( static::FLAG, false );
 	}
 
 
@@ -190,9 +197,10 @@ abstract class Upgrade {
 	}
 
 	/**
-	 * Restarts the processed items store.
+	 * Restarts the upgrade process.
 	 */
 	public function restart() {
+		delete_option( static::FLAG );
 		delete_option( $this->get_db_identifier() );
 	}
 }

--- a/loader.php
+++ b/loader.php
@@ -109,6 +109,16 @@ class Commons_In_A_Box {
 		require( $this->plugin_dir . 'includes/functions.php' );
 		require( $this->plugin_dir . 'includes/plugins.php' );
 
+		// Upgrades API.
+		// @todo maybe use autoloader.
+		require( $this->plugin_dir . 'includes/upgrades/upgrade-item.php' );
+		require( $this->plugin_dir . 'includes/upgrades/upgrade.php' );
+		require( $this->plugin_dir . 'includes/upgrades/upgrade-registry.php' );
+
+		if ( wp_doing_ajax() ) {
+			require( $this->plugin_dir . 'includes/upgrades/ajax-handler.php' );
+		}
+
 		// admin area
 		if ( cbox_is_admin() ) {
 			require( $this->plugin_dir . 'admin/admin-loader.php' );

--- a/loader.php
+++ b/loader.php
@@ -164,27 +164,26 @@ class Commons_In_A_Box {
 			add_action( 'cbox_plugins_loaded', array( 'Plugin_Dependencies', 'init' ), 91 );
 		}
 
-		// AJAX Upgrader routine.
-		add_action( 'cbox_load_components', function() {
-			// Bail if not doing AJAX.
-			if ( ! wp_doing_ajax() ) {
+		// Upgrader routine.
+		add_action( 'wp_loaded', function() {
+			// Ensure we're in the admin area.
+			if ( ! is_admin() ) {
 				return;
 			}
 
-			// Bail if not on our special AJAX hooks.
-			if ( empty( $_POST['action'] ) ||  ( 0 !== strpos( $_POST['action'], 'cbox_' ) && false === strpos( $_POST['action'], '_upgrade' ) ) ) {
-				return;
-			}
-
-			// Ensure upgrader items are registered on AJAX.
+			// Ensure upgrader items are registered.
 			$packages = cbox_get_packages();
 			$current  = cbox_get_current_package_id();
 			if ( isset( $packages[$current] ) && class_exists( $packages[$current] ) ) {
 				call_user_func( array( $packages[$current], 'upgrader' ) );
 			}
 
-			// Register AJAX routine.
-			require $this->plugin_dir . 'includes/upgrades/ajax-handler.php';
+			// AJAX handler.
+			if ( wp_doing_ajax() && ! empty( $_POST['action'] ) &&
+				( 0 === strpos( $_POST['action'], 'cbox_' ) && false !== strpos( $_POST['action'], '_upgrade' ) )
+			) {
+				require CBOX_PLUGIN_DIR . 'includes/upgrades/ajax-handler.php';
+			}
 		} );
 	}
 


### PR DESCRIPTION
Hello folks,

I wanted to get your options on this POC.

Mission features:
- [ ] Version check.
- [ ] Package dependency check.

The code is based on the WP Batch Processing plugin.

Example upgrade [code](https://gist.github.com/Mamaduka/562f772d42d44197902f7c608b0b9ae0) for cuny-academic-commons/cbox-openlab-core#10.

Maybe instead of version check, we hide upgrades that are finished (all items processed)? This way we can still display upgrades when something fails and needs admins attention.

We can do the same for package dependencies. Hide upgrade if package isn't active.

### Screens
![upgrades-list-table](https://user-images.githubusercontent.com/240569/84502292-22c59700-acc9-11ea-811b-da3b0f807ad6.jpg)
![upgrades-single-view](https://user-images.githubusercontent.com/240569/84502299-25c08780-acc9-11ea-9cf7-8235780ca2f5.jpg)

P.S. Sorry if I put files in the wrong places 😅

