### PR TITLE
Adds WP CLI commands for Upgrades API

### DIFF
--- a/includes/CLI/Upgrade.php
+++ b/includes/CLI/Upgrade.php
@@ -114,5 +114,11 @@ class Upgrade extends \WP_CLI_Command {
 		// Mark process as finished.
 		$upgrade->finish();
 		$progress->finish();
+
+		WP_CLI::success( sprintf(
+			'Processed %1$d items from total %2$d.',
+			$upgrade->get_processed_count(),
+			$upgrade->get_items_count()
+		) );
 	}
 }

--- a/includes/CLI/Upgrade.php
+++ b/includes/CLI/Upgrade.php
@@ -1,0 +1,118 @@
+<?php
+namespace CBOX\CLI;
+
+use WP_CLI;
+use CBOX\Upgrades\Upgrade_Registry;
+
+/**
+ * Commands applicable to a CBOX Upgrades API.
+ *
+ * ## EXAMPLES
+ *
+ *     # List the available upgrades.
+ *     $ wp cbox upgrade list
+ *
+ * @package cbox
+ */
+class Upgrade extends \WP_CLI_Command {
+	/**
+	 * Lists all available upgrades.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific fields.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields will be displayed by default for each upgrade:
+	 *
+	 * * ID
+	 * * Name
+	 * * Total
+	 * * Processed
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List the available upgrades.
+	 *     $ wp cbox upgrade list
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$upgrades = Upgrade_Registry::get_instance()->get_all_registered();
+
+		$r = array_merge( [
+			'format' => 'table',
+			'fields' => [ 'ID', 'Name', 'Total', 'Processed' ]
+		], $assoc_args );
+
+		if ( ! is_array( $r['fields'] ) ) {
+			$r['fields'] = explode( ',', $r['fields'] );
+		}
+
+		// Sanity check!
+		if ( empty( $upgrades ) ) {
+			WP_CLI::error( 'No upgrades are available.' );
+		}
+
+		$items = [];
+		foreach ( $upgrades as $upgrade ) {
+			$items[] = [
+				'ID'        => $upgrade->id,
+				'Name'      => $upgrade->name,
+				'Total'     => $upgrade->get_items_count(),
+				'Processed' => $upgrade->get_processed_count(),
+			];
+		}
+
+		WP_CLI\Utils\format_items( $r['format'], $items, $r['fields'] );
+	}
+
+	/**
+	 * Run the upgrade.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <upgrade-id>
+	 * : The upgrade ID.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp cbox upgrade run upgrade_nav_menus
+	 */
+	public function run( $args, $assoc_args ) {
+		list( $id ) = $args;
+
+		/** @var \CBOX\Upgrades\Upgrade */
+		$upgrade = Upgrade_Registry::get_instance()->get_registered( $id );
+
+		if ( ! $upgrade ) {
+			WP_CLI::error( sprintf( 'Upgrade "%s" does not exist.', $id ) );
+		}
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Running the upgrade', $upgrade->get_items_count() );
+
+		while ( $item = $upgrade->get_next_item() ) {
+			$upgrade->process( $item );
+			$upgrade->mark_as_processed( $item->id );
+
+			$progress->tick();
+		}
+
+		// Mark process as finished.
+		$upgrade->finish();
+		$progress->finish();
+	}
+}

--- a/loader.php
+++ b/loader.php
@@ -119,7 +119,7 @@ class Commons_In_A_Box {
 		}
 
 		// Upgrades API - runs in admin area and on AJAX.
-		if ( is_admin() ) {
+		if ( is_admin() || defined( 'WP_CLI' ) ) {
 			// @todo maybe use autoloader.
 			require( $this->plugin_dir . 'includes/upgrades/upgrade-item.php' );
 			require( $this->plugin_dir . 'includes/upgrades/upgrade.php' );
@@ -166,16 +166,14 @@ class Commons_In_A_Box {
 
 		// Upgrader routine.
 		add_action( 'wp_loaded', function() {
-			// Ensure we're in the admin area.
-			if ( ! is_admin() ) {
-				return;
-			}
-
-			// Ensure upgrader items are registered.
-			$packages = cbox_get_packages();
-			$current  = cbox_get_current_package_id();
-			if ( isset( $packages[$current] ) && class_exists( $packages[$current] ) ) {
-				call_user_func( array( $packages[$current], 'upgrader' ) );
+			// Ensure we're in the admin area or WP CLI.
+			if ( is_admin() || defined( 'WP_CLI') ) {
+				// Ensure upgrader items are registered.
+				$packages = cbox_get_packages();
+				$current  = cbox_get_current_package_id();
+				if ( isset( $packages[ $current ] ) && class_exists( $packages[ $current ] ) ) {
+					call_user_func( array( $packages[ $current ], 'upgrader' ) );
+				}
 			}
 
 			// AJAX handler.
@@ -208,6 +206,7 @@ class Commons_In_A_Box {
 			\WP_CLI::add_command( 'cbox',         '\CBOX\CLI\Core' );
 			\WP_CLI::add_command( 'cbox package', '\CBOX\CLI\Package' );
 			\WP_CLI::add_command( 'cbox update',  '\CBOX\CLI\Update' );
+			\WP_CLI::add_command( 'cbox upgrade', '\CBOX\CLI\Upgrade' );
 		}
 
 		/**


### PR DESCRIPTION
See #235.

@r-a-y had to make small [changes](https://github.com/cuny-academic-commons/commons-in-a-box/commit/fc6ff1f490443c239b4a353ba081d4bdc30f0647#diff-887e0958ad44327fdea08f6bec848329R122) to how Upgrades API and package upgrades are loaded. Hope this is okay.