### PR TITLE
Introduce plugin post-install routine

### DIFF
--- a/includes/classic/plugin-post-install/buddypress.php
+++ b/includes/classic/plugin-post-install/buddypress.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Classic: Post-install routine for the BuddyPress plugin.
+ *
+ * @since 1.7.0
+ */
+
+// Get current theme.
+$theme = cbox_get_theme();
+
+/*
+ * Fix a problem with CBOX Theme when updating BuddyPress to v11.4.4+.
+ *
+ * Drastic times calls for drastic measures!
+ *
+ * @see https://github.com/cuny-academic-commons/commons-in-a-box/issues/517#issuecomment-3141955221
+ */
+if ( ( version_compare( bp_get_version(), '11.4.4' ) < 0 ) && $theme->get_template() === cbox_get_theme_prop( 'directory_name' ) ) {
+	$ajax = BP_PLUGIN_DIR . 'bp-themes/bp-default/_inc/ajax.php';
+
+	/*
+	 * cbox-theme 1.6.0 has a hardcoded require line for bp-default's ajax.php.
+	 *
+	 * When we update BuddyPress to v11.4.4+, this file no longer exists and will
+	 * cause a fatal error. To address this, we're going to add back this ajax.php
+	 * as a dummy file.
+	 */
+	if ( ! file_exists( $ajax ) ) {
+		wp_mkdir_p( BP_PLUGIN_DIR . 'bp-themes/bp-default/_inc/' );
+		file_put_contents( $ajax, '<?php' );
+	}
+}

--- a/includes/package.php
+++ b/includes/package.php
@@ -109,6 +109,23 @@ abstract class CBox_Package {
 				}
 			} );
 		} );
+
+		// Plugin routine after updating a plugin.
+		add_action( 'cbox_before_updater', function() {
+			add_filter( 'upgrader_post_install', function( $retval, $hook_extra, $result ) {
+				$class = new ReflectionClass( get_called_class() );
+
+				/*
+				 * Handle individual plugin post install routine if available.
+				 */
+				$file = dirname( $class->getFileName() ) . '/plugin-post-install/' . $result['destination_name'] . '.php';
+				if ( file_exists( $file ) ) {
+					require $file;
+				}
+
+				return $retval;
+			}, 10, 3);
+		} );
 	}
 
 	/**


### PR DESCRIPTION
It might be handy to do something after a plugin has finished updating during the CBOX update process.

CBOX 1.1.0 introduced similar functionality to set a plugin's defaults (see commit a8b0a82). This PR does the same thing, but for after a plugin install (see commit 0596b1b).

This feature was created to fix a problem with `cbox-theme` v1.6.0 requiring bp-default's `ajax.php` file. This file no longer exists in in BuddyPress v11.4.4+. See #517. With this new feature, we can do something directly after BuddyPress is updated. In this instance, we can add some checks to compare the BP version number and whether the current theme is using cbox-theme. When this passes, we'll add back the `ajax.php` file as a dummy file. Then, when upgrading cbox-theme to v1.7.0, no fatal errors will occur.